### PR TITLE
Use hosts correctly, document values for IP-based install

### DIFF
--- a/src/prod/templates/ingress.yaml
+++ b/src/prod/templates/ingress.yaml
@@ -13,7 +13,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -22,10 +24,8 @@ spec:
                   number: 7090
             path: /ng/api(/|$)(.*)
             pathType: ImplementationSpecific
-  {{- if .Values.global.ingress.tls.enabled }}
-    {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
     {{- end }}
+  {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -48,7 +48,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -57,10 +59,8 @@ spec:
                   number: 4000
             path: /sto/(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -83,7 +83,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -92,10 +94,8 @@ spec:
                   number: 7090
             path: /sto-manager/(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -118,7 +118,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -127,10 +129,8 @@ spec:
                   number: 6070
             path: /et-collector(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -153,7 +153,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -162,10 +164,8 @@ spec:
                   number: 9191
             path: /et(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -188,7 +188,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -197,10 +199,8 @@ spec:
                   number: 80
             path: /ng(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -223,7 +223,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -232,10 +234,8 @@ spec:
                   number: 7090
             path: /ci(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -258,7 +258,9 @@ metadata:
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -267,10 +269,8 @@ spec:
                   number: 6060
             path: /cv(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -285,13 +285,15 @@ kind: Ingress
 metadata:
   name: minio-ui
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
-annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- if .Values.global.ingress.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -300,10 +302,8 @@ spec:
                   number: 9000
             path: /minio
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -318,13 +318,15 @@ kind: Ingress
 metadata:
   name: logs-service-minio
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
-annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- if .Values.global.ingress.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -333,10 +335,8 @@ spec:
                   number: 9000
             path: /logs/
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -352,14 +352,16 @@ metadata:
   name: log-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -368,10 +370,8 @@ spec:
                   number: 8079
             path: /log-service(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -387,14 +387,16 @@ metadata:
   name: gateway
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -403,10 +405,8 @@ spec:
                   number: 80
             path: /gateway(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -422,14 +422,16 @@ metadata:
   name: access-control
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -438,10 +440,8 @@ spec:
                   number: 9006
             path: /authz(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -457,14 +457,16 @@ metadata:
   name: ti-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -473,10 +475,8 @@ spec:
                   number: 8078
             path: /ti-service(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -492,14 +492,16 @@ metadata:
   name: template-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -508,10 +510,8 @@ spec:
                   number: 15002
             path: /template(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -526,13 +526,15 @@ kind: Ingress
 metadata:
   name: delegate-proxy
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
+  {{- if .Values.global.ingress.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -541,10 +543,8 @@ spec:
                   number: 80
             path: /storage
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -560,14 +560,16 @@ metadata:
   name: pipeline-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -576,10 +578,8 @@ spec:
                   number: 12001
             path: /pipeline(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-   {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -595,14 +595,16 @@ metadata:
   name: notification-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -611,10 +613,8 @@ spec:
                   number: 9005
             path: /notifications(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -630,14 +630,16 @@ metadata:
   name: audit-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -646,10 +648,8 @@ spec:
                   number: 9005
             path: /audit(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -665,14 +665,16 @@ metadata:
   name: resourcegroup-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -681,10 +683,8 @@ spec:
                   number: 9005
             path: /resourcegroup(/|$)(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -700,14 +700,16 @@ metadata:
   name: verification-service
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -716,10 +718,8 @@ spec:
                   number: 7070
             path: /verification
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -734,13 +734,15 @@ kind: Ingress
 metadata:
   name: harness-manager-api
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
+  {{- if .Values.global.ingress.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -749,10 +751,8 @@ spec:
                   number: 9090
             path: /api
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -767,13 +767,15 @@ kind: Ingress
 metadata:
   name: harness-manager-stream
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
+  {{- if .Values.global.ingress.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -782,10 +784,8 @@ spec:
                   number: 9090
             path: /stream
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -801,14 +801,16 @@ metadata:
   name: ng-auth-ui
   namespace: {{ .Release.Namespace }}
   annotations:
-{{- if .Values.global.ingress.annotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+    {{- if .Values.global.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -817,10 +819,8 @@ spec:
                   number: 80
             path: /auth(.*)
             pathType: ImplementationSpecific
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}
@@ -835,13 +835,15 @@ kind: Ingress
 metadata:
   name: harness-ui
   namespace: {{ .Release.Namespace }}
-{{- if .Values.global.ingress.annotations }}
+  {{- if .Values.global.ingress.annotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.global.ingress.annotations "context" $ ) | nindent 4 }}
-{{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className | quote }}
   rules:
-    - http:
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
         paths:
           - backend:
               service:
@@ -850,10 +852,8 @@ spec:
                   number: 80
             path: /
             pathType: Prefix
+    {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- range .Values.global.ingress.hosts }}
-      host: {{ . | quote }}
-  {{- end }}
   tls:
     - hosts:
         {{- range .Values.global.ingress.hosts }}

--- a/src/prod/values.yaml
+++ b/src/prod/values.yaml
@@ -72,6 +72,8 @@ global:
         # Overrides the image tag whose default is the chart appVersion.
         tag: "1.5"
         digest: ""
+    # NOTE: for ip-based installs, either use sslip.io for an IP-encoded DNS name
+    # OR set the hosts entry to '*'
     hosts:
       - 'my-host.example.org'
     tls:


### PR DESCRIPTION
Use the hosts field correctly, even in non-SSL installs; document IP-based install in values; standardize annotations indentation.