### PR TITLE
feat[CHAOS-785]: add Chaos module support in SMP

### DIFF
--- a/src/harness/Chart.lock
+++ b/src/harness/Chart.lock
@@ -29,5 +29,8 @@ dependencies:
 - name: policy-mgmt
   repository: https://harness.github.io/helm-policy-mgmt
   version: 0.2.0
-digest: sha256:35a98ccc04224c0e4ccedb221f1c709181fe98ba6c6b0d744cb36cf4400c8934
-generated: "2023-02-15T14:27:22.560091+05:30"
+- name: chaos
+  repository: https://harness.github.io/helm-chaos
+  version: 0.1.0
+digest: sha256:b289f3d9ea6153dea8cdbf53261dc7f9e1fd5cf0ef7bb08de853a2342d911201
+generated: "2023-02-15T16:13:54.379336+05:30"

--- a/src/harness/Chart.yaml
+++ b/src/harness/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/src/harness/Chart.yaml
+++ b/src/harness/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -71,3 +71,8 @@ dependencies:
     condition: global.opa.enabled
     version: 0.2.x
     repository: "https://harness.github.io/helm-policy-mgmt"
+
+  - name: chaos
+    condition: global.chaos.enabled
+    version: 0.1.x
+    repository: "https://harness.github.io/helm-chaos"

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -38,6 +38,9 @@ global:
   # -- Enable to install opa(beta)
   opa:
     enabled: false
+  # -- Enable to install Chaos(beta)
+  chaos:
+    enabled: false
   # --  Enabled will not send invites to email and autoaccepts
   saml:
     autoaccept: false
@@ -317,3 +320,16 @@ ccm:
 
 ng-manager:
   ceGcpSetupConfigGcpProjectId: "placeHolder"
+
+chaos:
+  chaos-manager:
+    nodeSelector: {}
+    tolerations: []
+
+  chaos-driver:
+    nodeSelector: {}
+    tolerations: []
+
+  chaos-web:
+    nodeSelector: {}
+    tolerations: []

--- a/src/override-demo.yaml
+++ b/src/override-demo.yaml
@@ -40,6 +40,9 @@ global:
   ccm:
     # -- Enable to install Cloud Cloud Management
     enabled: false
+  chaos:
+    # -- Enable to install Chaos components
+    enabled: false
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -560,3 +563,33 @@ ccm:
 
 ng-manager:
   ceGcpSetupConfigGcpProjectId: "placeHolder"
+
+chaos:
+  chaos-manager:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 1500m
+        memory: 2048Mi
+      requests:
+        cpu: 1500m
+        memory: 2048Mi
+
+  chaos-driver:
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        memory: 512Mi
+
+  chaos-web:
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi

--- a/src/override-prod.yaml
+++ b/src/override-prod.yaml
@@ -40,6 +40,9 @@ global:
   ccm:
     # -- Enable to install Cloud Cloud Management
     enabled: false
+  chaos:
+    # -- Enable to install Chaos components
+    enabled: false
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -633,3 +636,33 @@ ccm:
 
 ng-manager:
   ceGcpSetupConfigGcpProjectId: "placeHolder"
+
+chaos:
+  chaos-manager:
+    replicaCount: 1
+    resources:
+      limits:
+        cpu: 1500m
+        memory: 2048Mi
+      requests:
+        cpu: 1500m
+        memory: 2048Mi
+
+  chaos-driver:
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        memory: 512Mi
+
+  chaos-web:
+    replicaCount: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi


### PR DESCRIPTION
This PR has a dependancy on https://github.com/harness/helm-platform/pull/49, [PR](https://github.com/harness/helm-platform/pull/49) should be merged as well in order to add CHAOS module support.

In order to install CHAOS module, user needs to toggle the below fields to true in .Values.yaml they are using while helm installation -
```
global:
    chaos:
      # -- Enable to install Chaos components
      enabled: true
```
By default, it will be set to `false`.

If you want to update some configuration values for chaos then it can be handled with the configuration updates as below -
```
chaos:
  chaos-manager:
    replicaCount: 1
    resources:
      limits:
        cpu: 1500m
        memory: 2048Mi
      requests:
        cpu: 1500m
        memory: 2048Mi

  chaos-driver:
    replicaCount: 3
    resources:
      limits:
        cpu: 500m
        memory: 512Mi
      requests:
        memory: 512Mi

  chaos-web:
    replicaCount: 3
    resources:
      limits:
        cpu: 500m
        memory: 512Mi
      requests:
        cpu: 500m
        memory: 512Mi

```

Signed-off-by: Sagar Kumar <sagar.kumar@harness.io>