### PR TITLE
feat: [CDS-70575]: added ingress rule for approvals API in pipeline-service

### DIFF
--- a/src/harness/templates/ingress.yaml
+++ b/src/harness/templates/ingress.yaml
@@ -860,6 +860,13 @@ spec:
                   number: 12001
             path: /(v1/orgs/.+/projects/.+/input-sets.*)
             pathType: ImplementationSpecific
+          - backend:
+              service:
+                name: pipeline-service
+                port:
+                  number: 12001
+            path: /(v1/orgs/.+/projects/.+/approvals/.+)
+            pathType: ImplementationSpecific            
     {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:


### PR DESCRIPTION
Adding ingress rule for a new approvals openAPI in smp.

Tested in preqa and qa: [PR ](https://github.com/wings-software/ng-prod-manifests/pull/2953)