### PR TITLE
feat: [CET-1354]: Initial CET commit. 

### DIFF
--- a/src/generate-image.yaml
+++ b/src/generate-image.yaml
@@ -35,4 +35,4 @@ ccm:
   clickhouse:
     enabled: true
 cet:
-    enable-receivers: true
+  enable-receivers: true

--- a/src/generate-image.yaml
+++ b/src/generate-image.yaml
@@ -29,8 +29,10 @@ global:
     enabled: false
     autocud:
       enabled: false
+  cet:
+    enabled: true
 ccm:
   clickhouse:
     enabled: true
-srm:
-  enable-receivers: true
+cet:
+    enable-receivers: true

--- a/src/harness/Chart.yaml
+++ b/src/harness/Chart.yaml
@@ -36,10 +36,6 @@ dependencies:
     condition: global.ci.enabled
     version: 0.5.x
     repository: "file://ci"
-  - name: srm
-    condition: global.srm.enabled
-    version: 0.8.x
-    repository: "https://harness.github.io/helm-srm"
   - name: ngcustomdashboard
     condition: global.ngcustomdashboard.enabled
     version: 0.7.x
@@ -64,3 +60,7 @@ dependencies:
     condition: global.chaos.enabled
     version: 0.5.x
     repository: "https://harness.github.io/helm-chaos"
+  - name: cet
+    condition: global.cet.enabled
+    version: 0.1.x
+    repository: "https://harness.github.io/helm-cet"

--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -69,6 +69,9 @@ global:
   chaos:
     # -- Enable to install Chaos components(Beta)
     enabled: false
+  cet:
+    # -- Enable to install CET
+    enabled: false
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -584,7 +587,8 @@ infra:
           cpu: 2
           memory: 4Gi
 
-srm:
+
+cet:
   enable-receivers: false
   et-service:
     et:

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -69,6 +69,9 @@ global:
   chaos:
     # -- Enable to install Chaos components(Beta)
     enabled: false
+  cet:
+    # -- Enable to install CET
+    enabled: false
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -583,7 +586,7 @@ infra:
         requests:
           cpu: 4
           memory: 8192Mi
-srm:
+cet:
   enable-receivers: true
   et-service:
     et:
@@ -591,7 +594,7 @@ srm:
         heapSize: "6400m"
       redis:
         enabled: true
-    replicaCount: 1
+    replicaCount: 2
     resources:
       limits:
         memory: 8Gi
@@ -604,10 +607,6 @@ srm:
         heapSize: "1600m"
       redis:
         enabled: true
-    autoscaling:
-      enabled: true
-      maxReplicas: 3
-
     replicaCount: 1
     resources:
       limits:
@@ -630,7 +629,7 @@ srm:
       limits:
         memory: 2Gi
       requests:
-        cpu: 100m
+        cpu: 250m
         memory: 2Gi
   et-receiver-decompile:
     name: et-receiver-decompile
@@ -647,7 +646,7 @@ srm:
       limits:
         memory: 2Gi
       requests:
-        cpu: 100m
+        cpu: 250m
         memory: 2Gi
   et-receiver-agent:
     name: et-receiver-agent
@@ -664,7 +663,7 @@ srm:
       limits:
         memory: 2Gi
       requests:
-        cpu: 100m
+        cpu: 250m
         memory: 2Gi
   et-receiver-sql:
     name: et-receiver-sql
@@ -681,7 +680,7 @@ srm:
       limits:
         memory: 2Gi
       requests:
-        cpu: 100m
+        cpu: 250m
         memory: 2Gi
 
 ngcustomdashboard:

--- a/src/harness/templates/destinationrule.yaml
+++ b/src/harness/templates/destinationrule.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.global.istio.enabled .Values.global.srm.enabled -}}
+{{- if and .Values.global.istio.enabled .Values.global.cet.enabled -}}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -73,6 +73,9 @@ global:
   # -- Enable to install Chaos Engineering (CE) (Beta)
   chaos:
     enabled: false
+  # -- Enable to install Continuous Error Tracking (CET)
+  cet:
+    enabled: false
   migrator:
     enabled: false
   # --  SAML auto acceptance. Enabled will not send invites to email and autoaccepts
@@ -219,8 +222,8 @@ infra:
     auth:
       existingSecret: "postgres"
 
-# -- Config for Site Reliability Management (SRM)
-srm:
+# -- Config for Continuous Error Tracking (CET)
+cet:
   # -- Flag to enable error-tracking (ET) receivers
   enable-receivers: false
 


### PR DESCRIPTION
The change introduces the Continuous Error Tracking as an independent module moving the error-tracking sub-charts to the new helm-cet repos. This removes the need for the "SRM" sub-chart dependencies

Note: SRM still has a global flag which enables the SRM related Feature Flags as cv-nextgen is installed as part of the platform chart.