### PR TITLE
SMP-1268: Remove cpu from resources.limits for Redis

### DIFF
--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -435,7 +435,6 @@ platform:
     redis:
       resources:
         limits:
-          cpu: 1
           memory: 2048Mi
         requests:
           cpu: 1
@@ -444,7 +443,6 @@ platform:
     sentinel:
       resources:
         limits:
-          cpu: 100m
           memory: 200Mi
         requests:
           cpu: 100m

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -434,7 +434,6 @@ platform:
     redis:
       resources:
         limits:
-          cpu: 1
           memory: 2048Mi
         requests:
           cpu: 1
@@ -443,7 +442,6 @@ platform:
     sentinel:
       resources:
         limits:
-          cpu: 100m
           memory: 200Mi
         requests:
           cpu: 100m


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)