### PR TITLE
Updated generate image script to remove duplicate

### DIFF
--- a/src/generate-image-list.sh
+++ b/src/generate-image-list.sh
@@ -2,7 +2,12 @@
 
 SCRIPT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
-helm template ${SCRIPT_DIR}/harness -f  ${SCRIPT_DIR}/generate-image.yaml | grep -i image | grep \/ | grep -v imagePullPolicy | grep -v "#" | awk '{$1=$1};1' | sort -u | sed 's/^[^:]*: //g' | sed -e "s/^'//" -e "s/'$//"| sed -e 's/^"//' -e 's/"$//' > ${SCRIPT_DIR}/harness/images.txt
+helm template ${SCRIPT_DIR}/harness -f  ${SCRIPT_DIR}/generate-image.yaml | grep -i image | grep \/ | grep -v imagePullPolicy | grep -v "#" | awk '{$1=$1};1' | sort -u | sed 's/^[^:]*: //g' | sed -e "s/^'//" -e "s/'$//"| sed -e 's/^"//' -e 's/"$//' > ${SCRIPT_DIR}/harness/images_tmp.txt
+
+# Remove duplicates based on image name and tag
+awk -F: '{ print $1 ":" $2 }' ${SCRIPT_DIR}/harness/images_tmp.txt | sort -u > ${SCRIPT_DIR}/harness/images.txt
+
+rm ${SCRIPT_DIR}/harness/images_tmp.txt
 
 # Add minimal images
 IMAGES=("docker.io/harness/delegate:[0-9.]+" "docker.io/harness/delegate-proxy-signed:[0-9.]+")
@@ -14,5 +19,9 @@ do
         echo "$MATCHES" | sed "s/$/${SUFFIX[i]}/" | tee -a src/harness/images.txt
     fi
 done
+
+# Remove duplicates one more time in case minimal images have added any
+awk -F: '{ print $1 ":" $2 }' ${SCRIPT_DIR}/harness/images.txt | sort -u > ${SCRIPT_DIR}/harness/images_tmp.txt
+mv ${SCRIPT_DIR}/harness/images_tmp.txt ${SCRIPT_DIR}/harness/images.txt
 
 exit 0

--- a/src/generate-image.yaml
+++ b/src/generate-image.yaml
@@ -23,10 +23,8 @@ global:
     enabled: true
   ng:
     enabled: true
-  lwd:
+  chaos:
     enabled: true
-    autocud:
-      enabled: true
 ccm:
   clickhouse:
     enabled: true


### PR DESCRIPTION
Updated generate image script to avoid duplicate entries based on image name and tag.

Example of duplicates in old version:
docker.io/plugins/s3:1.2.3
plugins/s3:1.2.3

With new version, it will check for image name and tag, if its same, only add one entry.

Added enabled chaos module in yaml.

Tested locally, working as expected.
