### PR TITLE
SMP-1555: remove chart.lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@
 
 # Chart dependencies
 **/charts/
-
-# Chart lock file
-**/Chart.lock

--- a/src/harness/Chart.lock
+++ b/src/harness/Chart.lock
@@ -1,0 +1,36 @@
+dependencies:
+- name: infra
+  repository: file://infra
+  version: 0.4.0
+- name: platform
+  repository: https://harness.github.io/helm-platform
+  version: 0.7.12
+- name: sto
+  repository: https://harness.github.io/helm-sto
+  version: 0.7.3
+- name: ci
+  repository: file://ci
+  version: 0.4.0
+- name: srm
+  repository: https://harness.github.io/helm-srm
+  version: 0.7.2
+- name: ngcustomdashboard
+  repository: https://harness.github.io/helm-dashboards
+  version: 0.6.3
+- name: ff
+  repository: https://harness.github.io/helm-ff
+  version: 0.7.2
+- name: ccm
+  repository: https://harness.github.io/helm-ccm
+  version: 0.7.5
+- name: gitops
+  repository: https://harness.github.io/helm-gitops
+  version: 0.5.10
+- name: policy-mgmt
+  repository: https://harness.github.io/helm-policy-mgmt
+  version: 0.5.3
+- name: chaos
+  repository: https://harness.github.io/helm-chaos
+  version: 0.4.0
+digest: sha256:98c01ad4a24ede78db366ecfff22542d868230225a7c379dfff05a7631e8626b
+generated: "2023-06-27T23:53:34.2126-07:00"

--- a/src/harness/ci/Chart.lock
+++ b/src/harness/ci/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: ci-manager
+  repository: https://harness.github.io/helm-ci-manager
+  version: 0.5.6
+digest: sha256:4b0c07b1c240176427add0c7a7ad4fbdcec85b2267334e00f2a33fe95bd2d1e8
+generated: "2023-06-27T23:51:52.917896-07:00"

--- a/src/harness/infra/Chart.lock
+++ b/src/harness/infra/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.6.16
+digest: sha256:fa439475aaaefbdea274cfdacadc960820bce04bf37e43043584e6b4e19cd1d5
+generated: "2023-06-27T23:52:51.56355-07:00"


### PR DESCRIPTION
Jira: https://harness.atlassian.net/browse/SMP-1555

- Removed Chart.lock file from Gitignore and ran "helm dependency update" for src/harness/ci, src/harness/infra and src/harness. 