### PR TITLE
Added default env variable

### DIFF
--- a/src/harness/scripts/create-airgap-bundle.sh
+++ b/src/harness/scripts/create-airgap-bundle.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+
 images="harness-airgapped-images.tgz"
 list="airgapped-images.txt"
 


### PR DESCRIPTION
Currrent airgap bundle script download binaries based on which arch machine is used to run the script.

This export DOCKER_DEFAULT_PLATFORM=linux/amd64 variable will make sure it always download amd64 architecture.

Tested locally