### PR TITLE
Script for validating airgap bundle for correctness

### DIFF
--- a/src/airgap/validate_airgap.sh
+++ b/src/airgap/validate_airgap.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+MODULE_NAMES=("platform" "ccm" "cdng" "ci" "ce" "sto" "cet" "ff")
+
+abort() {
+    echo "Error: $1"
+    exit 1
+}
+
+for module_name in "${MODULE_NAMES[@]}"; do
+    TGZ_FILE="${module_name}_images.tgz"
+    TXT_FILE="${module_name}_images.txt"
+
+    [[ ! -f "${TGZ_FILE}" ]] && abort "${TGZ_FILE} not found!"
+
+    # Extract the image tags and format them
+    IMAGES_LIST=$(tar -xzOf "${TGZ_FILE}" manifest.json | jq -r '.[].RepoTags | join("\n")')
+
+    [[ ! -f "${TXT_FILE}" ]] && abort "${TXT_FILE} not found!"
+
+    echo "Matching images for ${TGZ_FILE} and ${TXT_FILE}:"
+    
+    mismatched=false
+
+    # Count the number of images in .tgz and .txt
+    num_images_tgz=$(echo "$IMAGES_LIST" | wc -l)
+    num_images_txt=$(wc -l < "${TXT_FILE}")
+
+    if [ "$num_images_tgz" -ne "$num_images_txt" ]; then
+        abort "Number of images in ${TGZ_FILE} does not match ${TXT_FILE}"
+    fi
+
+    while IFS= read -r line; do
+        line_without_prefix="${line#docker.io/}"
+        
+        if [[ "$IMAGES_LIST" =~ "$line" || "$IMAGES_LIST" =~ "$line_without_prefix" ]]; then
+            echo "$line"
+        else
+            mismatched=true
+            echo "Mismatch found: $line"
+        fi
+    done < "${TXT_FILE}"
+
+    if $mismatched; then
+        abort "Images in ${TGZ_FILE} and ${TXT_FILE} do not match"
+    fi
+
+    echo "--------------------------------"
+done


### PR DESCRIPTION

Validates each airgap bundle with its respective list of images.

Testing:
When tags don't match:
![Screenshot 2023-10-03 at 10 35 14 AM](https://github.com/harness/helm-charts/assets/126604111/258c134a-6a14-4d7a-b835-44c0c7b81555)


When all images match:
![Screenshot 2023-10-03 at 10 34 28 AM](https://github.com/harness/helm-charts/assets/126604111/2ec24b63-ea11-452d-9519-6514584f0937)


When number of images do not match:
![Screenshot 2023-10-03 at 10 33 27 AM](https://github.com/harness/helm-charts/assets/126604111/570a97c5-77ce-4de0-96e0-367e0db984dc)
