### PR TITLE
fix:[SMP-2121]: Fix for invalidation errors in override files

### DIFF
--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -1,6 +1,18 @@
 global:
   # -- Enable for complete airgap environment
   airgap: false
+  # -- By default aws sdk uses respective services endpoint urls but in case we want to provide custom those endpoint urls we can use following
+  # -- Set global.awsServiceEndpointUrls.enabled to true if we want to enable custom endpoint urls
+  # -- Set global.awsServiceEndpointUrls.endPointRegion.host to valid AWS region where this endpoint is available
+  # -- Set global.awsServiceEndpointUrls.stsEndPointUrl to set sts endpoint url
+  # -- Set global.awsServiceEndpointUrls.ecsEndPointUrl to set ecs endpoint url
+  # -- Set global.awsServiceEndpointUrls.cloudwatchEndPointUrl to set cloud watch endpoint url
+  awsServiceEndpointUrls:
+    cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
+    ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
+    enabled: false
+    endPointRegion: us-east-2
+    stsEndPointUrl: https://sts.us-east-2.amazonaws.com
   ccm:
     # -- Enable to install Cloud Cloud Management
     enabled: false
@@ -169,6 +181,18 @@ global:
   opa:
     # -- Enable to install Open Policy Agent
     enabled: false
+  # -- Set global.proxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
+  # -- Set global.proxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
+  # -- Set global.proxy.port to proxy port, it takes integer value
+  # -- Set global.proxy.username and global.proxy.password to proxy username and password, if not required remove it or keep blank
+  # -- Set global.proxy.protocol to http or https depending on the proxy configuration
+  proxy:
+    enabled: false
+    host: localhost
+    password: ""
+    port: 80
+    protocol: http
+    username: ""
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -189,42 +213,10 @@ global:
   useImmutableDelegate: "true"
   # -- Set true to use delegate minimal image
   useMinimalDelegateImage: false
-  # -- Set global.proxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
-  # -- Set global.proxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
-  # -- Set global.proxy.port to proxy port, it takes integer value
-  # -- Set global.proxy.username and global.proxy.password to proxy username and password, if not required remove it or keep blank
-  # -- Set global.proxy.protocol to http or https depending on the proxy configuration
-  proxy:
-    enabled: false
-    host: localhost
-    port: 80
-    username: ""
-    password: ""
-    protocol: http
-  # -- By default aws sdk uses respective services endpoint urls but in case we want to provide custom those endpoint urls we can use following
-  # -- Set global.awsServiceEndpointUrls.enabled to true if we want to enable custom endpoint urls
-  # -- Set global.awsServiceEndpointUrls.endPointRegion.host to valid AWS region where this endpoint is available
-  # -- Set global.awsServiceEndpointUrls.stsEndPointUrl to set sts endpoint url
-  # -- Set global.awsServiceEndpointUrls.ecsEndPointUrl to set ecs endpoint url
-  # -- Set global.awsServiceEndpointUrls.cloudwatchEndPointUrl to set cloud watch endpoint url
-  awsServiceEndpointUrls:
-    enabled: false
-    endPointRegion: us-east-2
-    stsEndPointUrl: https://sts.us-east-2.amazonaws.com
-    ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
-    cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
 ccm:
   batch-processing:
     awsAccountTagsCollectionJobConfig:
       enabled: true
-    cloudProviderConfig:
-      CLUSTER_DATA_GCS_BACKUP_BUCKET: "placeHolder"
-      CLUSTER_DATA_GCS_BUCKET: "placeHolder"
-      DATA_PIPELINE_CONFIG_GCS_BASE_PATH: "placeHolder"
-      GCP_PROJECT_ID: "placeHolder"
-      S3_SYNC_CONFIG_BUCKET_NAME: "placeHolder"
-      S3_SYNC_CONFIG_REGION: "placeHolder"
-    stackDriverLoggingEnabled: false
     # -- This proxy is used by S3 sync bucket aws cli command
     # -- Set ccm.batch-processing.cliProxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
     # -- Set ccm.batch-processing.cliProxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
@@ -234,20 +226,28 @@ ccm:
     cliProxy:
       enabled: false
       host: localhost
-      port: 80
-      username: ""
       password: ""
+      port: 80
       protocol: http
+      username: ""
+    cloudProviderConfig:
+      CLUSTER_DATA_GCS_BACKUP_BUCKET: "placeHolder"
+      CLUSTER_DATA_GCS_BUCKET: "placeHolder"
+      DATA_PIPELINE_CONFIG_GCS_BASE_PATH: "placeHolder"
+      GCP_PROJECT_ID: "placeHolder"
+      S3_SYNC_CONFIG_BUCKET_NAME: "placeHolder"
+      S3_SYNC_CONFIG_REGION: "placeHolder"
+    stackDriverLoggingEnabled: false
+  ce-nextgen:
+    cloudProviderConfig:
+      GCP_PROJECT_ID: "placeHolder"
+    stackDriverLoggingEnabled: false
   cloud-info:
     # -- Set ccm.cloud-info.proxy.httpsProxyEnabled to true if we want calls aws sdk calls to ec2, pricing to go through proxy
     # -- Set ccm.cloud-info.proxy.httpsProxyUrl to proxy url(ex: http://localhost:8080, if http proxy is running on localhost port 8080)
     proxy:
       httpsProxyEnabled: false
       httpsProxyUrl: http://localhost
-  ce-nextgen:
-    cloudProviderConfig:
-      GCP_PROJECT_ID: "placeHolder"
-    stackDriverLoggingEnabled: false
   event-service:
     stackDriverLoggingEnabled: false
 cet:

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -1,8 +1,18 @@
 global:
   # -- Enable for complete airgap environment
   airgap: false
-  # -- Enable this for autoscaling with Horizontal Pod Autoscaler
-  ha: true
+  # -- By default aws sdk uses respective services endpoint urls but in case we want to provide custom those endpoint urls we can use following
+  # -- Set global.awsServiceEndpointUrls.enabled to true if we want to enable custom endpoint urls
+  # -- Set global.awsServiceEndpointUrls.endPointRegion.host to valid AWS region where this endpoint is available
+  # -- Set global.awsServiceEndpointUrls.stsEndPointUrl to set sts endpoint url
+  # -- Set global.awsServiceEndpointUrls.ecsEndPointUrl to set ecs endpoint url
+  # -- Set global.awsServiceEndpointUrls.cloudwatchEndPointUrl to set cloud watch endpoint url
+  awsServiceEndpointUrls:
+    cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
+    ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
+    enabled: false
+    endPointRegion: us-east-2
+    stsEndPointUrl: https://sts.us-east-2.amazonaws.com
   ccm:
     # -- Enable to install Cloud Cloud Management
     enabled: false
@@ -171,6 +181,18 @@ global:
   opa:
     # -- Enable to install Open Policy Agent
     enabled: false
+  # -- Set global.proxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
+  # -- Set global.proxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
+  # -- Set global.proxy.port to proxy port, it takes integer value
+  # -- Set global.proxy.username and global.proxy.password to proxy username and password, if not required remove it or keep blank
+  # -- Set global.proxy.protocol to http or https depending on the proxy configuration
+  proxy:
+    enabled: false
+    host: localhost
+    password: ""
+    port: 80
+    protocol: http
+    username: ""
   saml:
     # --  Enabled will not send invites to email and autoaccepts
     autoaccept: false
@@ -191,47 +213,12 @@ global:
   useImmutableDelegate: "true"
   # -- Set true to use delegate minimal image
   useMinimalDelegateImage: false
-  # -- Set global.proxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
-  # -- Set global.proxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
-  # -- Set global.proxy.port to proxy port, it takes integer value
-  # -- Set global.proxy.username and global.proxy.password to proxy username and password, if not required remove it or keep blank
-  # -- Set global.proxy.protocol to http or https depending on the proxy configuration
-  proxy:
-    enabled: false
-    host: localhost
-    port: 80
-    username: ""
-    password: ""
-    protocol: http
-  # -- By default aws sdk uses respective services endpoint urls but in case we want to provide custom those endpoint urls we can use following
-  # -- Set global.awsServiceEndpointUrls.enabled to true if we want to enable custom endpoint urls
-  # -- Set global.awsServiceEndpointUrls.endPointRegion.host to valid AWS region where this endpoint is available
-  # -- Set global.awsServiceEndpointUrls.stsEndPointUrl to set sts endpoint url
-  # -- Set global.awsServiceEndpointUrls.ecsEndPointUrl to set ecs endpoint url
-  # -- Set global.awsServiceEndpointUrls.cloudwatchEndPointUrl to set cloud watch endpoint url
-  awsServiceEndpointUrls:
-    enabled: false
-    endPointRegion: us-east-2
-    stsEndPointUrl: https://sts.us-east-2.amazonaws.com
-    ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
-    cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
-gitops:
-  autoscaling:
-    enabled: false
-  replicaCount: 2
 ccm:
-  batch-processing:
+  anomaly-detection:
     replicaCount: 2
+  batch-processing:
     awsAccountTagsCollectionJobConfig:
       enabled: true
-    cloudProviderConfig:
-      CLUSTER_DATA_GCS_BACKUP_BUCKET: "placeHolder"
-      CLUSTER_DATA_GCS_BUCKET: "placeHolder"
-      DATA_PIPELINE_CONFIG_GCS_BASE_PATH: "placeHolder"
-      GCP_PROJECT_ID: "placeHolder"
-      S3_SYNC_CONFIG_BUCKET_NAME: "placeHolder"
-      S3_SYNC_CONFIG_REGION: "placeHolder"
-    stackDriverLoggingEnabled: false
     # -- This proxy is used by S3 sync bucket aws cli command
     # -- Set ccm.batch-processing.cliProxy.enabled to true if we want calls aws sdk calls to organization, cur, ce, iam to go through proxy
     # -- Set ccm.batch-processing.cliProxy.host to proxy host or Ip(ex: localhost, 127.0.0.1)
@@ -241,29 +228,37 @@ ccm:
     cliProxy:
       enabled: false
       host: localhost
-      port: 80
-      username: ""
       password: ""
+      port: 80
       protocol: http
-  cloud-info:
-    # -- Set ccm.cloud-info.proxy.httpsProxyEnabled to true if we want calls aws sdk calls to ec2, pricing to go through proxy
-    # -- Set ccm.cloud-info.proxy.httpsProxyUrl to proxy url(ex: http://localhost:8080, if http proxy is running on localhost port 8080)
-    proxy:
-      httpsProxyEnabled: false
-      httpsProxyUrl: http://localhost
+      username: ""
+    cloudProviderConfig:
+      CLUSTER_DATA_GCS_BACKUP_BUCKET: "placeHolder"
+      CLUSTER_DATA_GCS_BUCKET: "placeHolder"
+      DATA_PIPELINE_CONFIG_GCS_BASE_PATH: "placeHolder"
+      GCP_PROJECT_ID: "placeHolder"
+      S3_SYNC_CONFIG_BUCKET_NAME: "placeHolder"
+      S3_SYNC_CONFIG_REGION: "placeHolder"
+    replicaCount: 2
+    stackDriverLoggingEnabled: false
   ce-nextgen:
     cloudProviderConfig:
       GCP_PROJECT_ID: "placeHolder"
     stackDriverLoggingEnabled: false
-  event-service:
-    stackDriverLoggingEnabled: false
   cloud-info:
+    replicaCount: 2
+  cloud-info:
+    replicaCount: 2
+  event-service:
     replicaCount: 2
   event-service:
     replicaCount: 2
   telescopes:
     replicaCount: 2
-  anomaly-detection:
+cd:
+  gitops:
+    autoscaling:
+      enabled: false
     replicaCount: 2
 cet:
   enable-receivers: true


### PR DESCRIPTION
Initially causing: 
<img width="655" alt="image" src="https://github.com/harness/helm-charts/assets/105775781/e8ee2a70-fc57-4a98-bdc7-bbbb18220f32">
after running migrate script, the error is resolved.

Tested templating locally.