### PR TITLE
fix: [SMP-2254]: removed duplicate keys

### DIFF
--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -251,10 +251,6 @@ ccm:
     stackDriverLoggingEnabled: false
   cloud-info:
     replicaCount: 2
-  cloud-info:
-    replicaCount: 2
-  event-service:
-    replicaCount: 2
   event-service:
     replicaCount: 2
   telescopes:


### PR DESCRIPTION
Removed duplicate keys for cloud-info and event-service from override-prod.yaml