### PR TITLE
Feat: [SMP-1834]: Adding common helm unit tests

### DIFF
--- a/tests/config_test.yaml
+++ b/tests/config_test.yaml
@@ -1,0 +1,51 @@
+---
+suite: test config
+templates:
+  - config.yaml
+release:
+  namespace: harness-smp
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -3,7 +3,7 @@ suite: test deployment
 templates:
   - deployment.yaml
   - config.yaml
-  - secrets.yaml
+  - secret.yaml
 release:
   namespace: harness-smp
 tests:

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -1,0 +1,300 @@
+---
+suite: test deployment
+templates:
+  - deployment.yaml
+  - config.yaml
+  - secrets.yaml
+release:
+  namespace: harness-smp
+tests:
+  - it: should template without any override
+    templates:
+      - deployment.yaml
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations (deployment and podSpec)
+    templates:
+      - deployment.yaml
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels (deployment and podSpec)
+    templates:
+      - deployment.yaml
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    templates:
+      - deployment.yaml
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate replicaCount when autoscaling is disabled
+    templates:
+      - deployment.yaml
+    set:
+      autoscaling.enabled: false
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: validate replicaCount when autoscaling is disabled
+    templates:
+      - deployment.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
+
+  - it: validate strategy values (maxUnavailable and maxSurge)
+    templates:
+      - deployment.yaml
+    set:
+      maxSurge: 4
+      maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 4
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 2
+
+  - it: validate podAnnotations
+    templates:
+      - deployment.yaml
+    set:
+      podAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate podLabels
+    templates:
+      - deployment.yaml
+    set:
+      podLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate podSecurityContext
+    templates:
+      - deployment.yaml
+    set:
+      podSecurityContext: {fsGroup: 2000}
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: validate podAnnotations and commonAnnotations in pod spec
+    templates:
+      - deployment.yaml
+    set:
+      podAnnotations: {pod: annotated, add: this}
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            pod: annotated
+            add: this
+            foo: bar
+            hello: world
+
+  - it: validate podLabels and commonLabels in pod spec
+    templates:
+      - deployment.yaml
+    set:
+      podLabels: {pod: labeled, add: this}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            pod: labeled
+            add: this
+            foo: bar
+            hello: world
+
+
+  - it: validate main container values
+    templates:
+      - deployment.yaml
+    set:
+      image:
+        registry: docker.io
+        repository: harness/feature-signed
+        tag: 808xx
+        pullPolicy: Always
+        pullSecrets: [{name: mysecret}]
+      securityContext: {runAsUser: 1000}
+      lifecycleHooks:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "echo Hello"]
+      extraVolumeMounts: [{name: extras, mountPath: /extras}]
+      extraVolumes: [{name: extras, emptyDir: {}}]
+      resources:
+        limits:
+          cpu: 200m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - isSubset:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec
+          content:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - "echo Hello"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extras
+            mountPath: /extras
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extras
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/harness/feature-signed:808xx
+
+  - it: validate image with global image registry overrdide
+    templates:
+      - deployment.yaml
+    set:
+      global.imageRegistry: us.gcr.io
+      image:
+        registry: docker.io
+        repository: harness/feature-signed
+        tag: 808xx
+        pullPolicy: Always
+        pullSecrets: [{name: mysecret}]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: us.gcr.io/harness/feature-signed:808xx
+
+  - it: validate nodeSelector value
+    templates:
+      - deployment.yaml
+    set:
+      nodeSelector: {disktype: ssd}
+    asserts:
+      - isSubset:
+          path: spec.template.spec.nodeSelector
+          content:
+            disktype: ssd
+
+  - it: validate tolerations value
+    templates:
+      - deployment.yaml
+    set:
+      tolerations:
+        - key: "key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "key"
+            operator: "Equal"
+            value: "value"
+            effect: "NoSchedule"
+
+  - it: template with all values set
+    templates:
+      - deployment.yaml
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+      global.commonAnnotations: {foo: bar, hello: world}
+      autoscaling.enabled: false
+      podAnnotations: {pod: annotated, add: this}
+      podLabels: {pod: labeled, add: this}
+      podSecurityContext: {fsGroup: 2000}
+      securityContext: {runAsUser: 1000}
+      nodeSelector: {disktype: ssd}
+      tolerations:
+        - key: "key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
+      maxSurge: 4
+      maxUnavailable: 2
+      replicaCount: 3
+    asserts:
+      - notFailedTemplate: {}

--- a/tests/hpa_test.yaml
+++ b/tests/hpa_test.yaml
@@ -1,0 +1,170 @@
+---
+suite: test horizontal pod autoscaler
+
+templates:
+  - hpa.yaml
+
+set:
+  autoscaling.enabled: true
+
+release:
+  namespace: harness-smp
+
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  # TODO: Add Deployment or STS
+  # TODO: Add match for spec.scaleTargetRef.name with metadata.name
+  - it: should validate target ref is present
+    asserts:
+      - exists:
+          path: spec.scaleTargetRef
+      # - equal:
+      #     path: spec.scaleTargetRef.kind
+      #     value: Deployment
+      # - equal:
+      #     path: spec.scaleTargetRef.name
+      #     value: metadata.name
+
+  - it: validate API version for Kubernetes version 1.22.2
+    set:
+      global.kubeVersion: 1.22.2
+    asserts:
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2beta2
+
+  - it: validate API version for Kubernetes version 1.23.0
+    set:
+      global.kubeVersion: 1.23.0
+    asserts:
+      - equal:
+          path: apiVersion
+          value: autoscaling/v2
+
+  - it: validate target CPU for Kubernetes version 1.22.2
+    set:
+      global.kubeVersion: 1.22.2
+      autoscaling:
+        targetCPU: 500m
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.targetAverageUtilization
+          value: 500m
+
+  - it: validate target CPU for Kubernetes version 1.23.0
+    set:
+      global.kubeVersion: 1.23.0
+      autoscaling:
+        targetCPU: 500m
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - isSubset:
+          path: spec.metrics[0].resource.target
+          content:
+            type: Utilization
+            averageUtilization: 500m
+
+  - it: validate target Memory for Kubernetes version 1.22.2
+    set:
+      global.kubeVersion: 1.22.2
+      autoscaling:
+        targetMemory: 500Mi
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: memory
+      - equal:
+          path: spec.metrics[0].resource.targetAverageUtilization
+          value: 500Mi
+
+  - it: validate target Memory for Kubernetes version 1.23.0
+    set:
+      global.kubeVersion: 1.23.0
+      autoscaling:
+        targetMemory: 500Mi
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: memory
+      - isSubset:
+          path: spec.metrics[0].resource.target
+          content:
+            type: Utilization
+            averageUtilization: 500Mi
+
+  - it: should work with minReplicas provided
+    set:
+      autoscaling.minReplicas: 2
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+
+  - it: should work with maxReplicas provided
+    set:
+      autoscaling.maxReplicas: 10
+    asserts:
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: should work with both maxReplicas and minReplicas provided
+    set:
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10

--- a/tests/ingress_test.yaml
+++ b/tests/ingress_test.yaml
@@ -1,0 +1,236 @@
+---
+suite: test ingress
+templates:
+  - ingress.yaml
+release:
+  namespace: harness-smp
+set:
+  global.ingress.enabled: true
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: Ingress
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with ingress annotations
+    set:
+      ingress.annotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with ingress objects annotations
+    set:
+      global.ingress.objects.annotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and ingress annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      ingress.annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+
+  - it: should work with common annotations and ingress objects annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.ingress.objects.annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+
+  - it: should work with ingress annotations and ingress objects annotations
+    set:
+      ingress.annotations: {foo: bar, hello: world}
+      global.ingress.objects.annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+
+  - it: should work with all annotations (ingress, ingress objects and common)
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.ingress.objects.annotations: {objects: annotated}
+      ingress.annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+            objects: annotated
+
+  - it: should work with ingress class name
+    set:
+      global.ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should work with single ingress host
+    set:
+      global.ingress.hosts: [example.com]
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 1
+      - equal:
+          path: spec.rules[0].host
+          value: example.com
+
+  - it: should work with multiple ingress hosts
+    set:
+      global.ingress.hosts: [example.com, example2.com, example3.com]
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 3
+      - equal:
+          path: spec.rules[0].host
+          value: example.com
+      - equal:
+          path: spec.rules[1].host
+          value: example2.com
+      - equal:
+          path: spec.rules[2].host
+          value: example3.com
+
+  - it: should work with TLS enabled and hosts provided
+    set:
+      global:
+        ingress:
+          tls:
+            enabled: true
+            secretName: test-tls
+          hosts: [example.com, example2.com]
+    asserts:
+      - lengthEqual:
+          path: spec.tls
+          count: 1
+      - contains:
+          path: spec.tls
+          content:
+            hosts:
+              - example.com
+              - example2.com
+            secretName: test-tls
+
+  - it: should work with all values
+    set:
+      global:
+        commonAnnotations: {foo: bar, hello: world}
+        commonLabels: {foo: bar, hello: world}
+        ingress:
+          objects:
+            annotations: {objects: annotated}
+          className: nginx
+          tls:
+            enabled: true
+            secretName: test-tls
+          hosts: [example.com, example2.com, example3.com]
+      ingress:
+        annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+            objects: annotated
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+      - lengthEqual:
+          path: spec.tls
+          count: 1
+      - lengthEqual:
+          path: spec.rules
+          count: 3
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: example.com
+      - equal:
+          path: spec.rules[1].host
+          value: example2.com
+      - equal:
+          path: spec.rules[2].host
+          value: example3.com
+      - contains:
+          path: spec.tls
+          content:
+            hosts:
+              - example.com
+              - example2.com
+              - example3.com
+            secretName: test-tls

--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -1,0 +1,56 @@
+---
+suite: test pod disruption budget
+templates:
+  - pdb.yaml
+release:
+  namespace: harness-smp
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should validate the selector labels are present
+    asserts:
+      - exists:
+          path: spec.selector.matchLabels

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if both folder paths are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 /path/to/charts /path/to/tests"
+    exit 1
+fi
+
+folder1_path="$1"
+folder2_path="$2"
+
+# Get a list of files in folder1
+folder1_files=("$folder1_path/templates"/*)
+
+test_files=()
+# Iterate through each file in folder1
+for file1 in "${folder1_files[@]}"; do
+    # Extract the filename without the path
+    file1_name=$(basename "$file1")
+
+    # Check if the corresponding _test file exists in folder2
+    file2_name="${file1_name/.yaml/_test.yaml}"
+    file2_path="$folder2_path/$file2_name"
+
+    if [ -e "$file2_path" ]; then
+        test_files+=("-f $file2_path")
+    fi
+done
+
+test_input="${test_files[*]}"
+echo "Running tests for $test_input files"
+
+helm unittest $test_input $folder1_path --with-subchart=false
+

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -28,7 +28,20 @@ for file1 in "${folder1_files[@]}"; do
 done
 
 test_input="${test_files[*]}"
-echo "Running tests for $test_input files"
 
-helm unittest $test_input $folder1_path --with-subchart=false
+# Regex to remove the trim copying/deleting log spam
+regex_pattern='^[0-9]{4}/[0-9]{2}/[0-9]{2} ([0-9]{2}:[0-9]{2}:[0-9]{2}) (trim (copying|deleting) "(.*)")'
 
+command_output=$(helm unittest $test_input $folder1_path --with-subchart=false)
+exit_code=$?
+
+# Cleaning the output from the trim copying/deleting log spam
+cleaned_output=$(echo "$command_output" | awk -v pattern="$regex_pattern" '$0 !~ pattern')
+
+# Printing the cleaned output
+printf "%s\n" "$cleaned_output"
+
+# Exit if the tests failed
+if [ $exit_code -ne 0 ]; then
+    exit 1
+fi

--- a/tests/service_test.yaml
+++ b/tests/service_test.yaml
@@ -1,0 +1,74 @@
+---
+suite: test service
+templates:
+  - service.yaml
+release:
+  namespace: harness-smp
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with service annotations
+    set:
+      service.annotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with both service annotations and common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      service.annotations: {service: annotated, add: this}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this

--- a/tests/statefulset_test.yaml
+++ b/tests/statefulset_test.yaml
@@ -1,0 +1,281 @@
+---
+suite: test statefulset
+templates:
+  - statefulset.yaml
+  - config.yaml
+  - secrets.yaml
+release:
+  namespace: harness-smp
+tests:
+  - it: should template without any override
+    templates:
+      - statefulset.yaml
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations (deployment and podSpec)
+    templates:
+      - statefulset.yaml
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels (deployment and podSpec)
+    templates:
+      - statefulset.yaml
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    templates:
+      - statefulset.yaml
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate replicaCount when autoscaling is disabled
+    templates:
+      - statefulset.yaml
+    set:
+      autoscaling.enabled: false
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+  - it: validate replicaCount when autoscaling is disabled
+    templates:
+      - statefulset.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
+
+  - it: validate podAnnotations
+    templates:
+      - statefulset.yaml
+    set:
+      podAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate podLabels
+    templates:
+      - statefulset.yaml
+    set:
+      podLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: validate podSecurityContext
+    templates:
+      - statefulset.yaml
+    set:
+      podSecurityContext: {fsGroup: 2000}
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: validate podAnnotations and commonAnnotations in pod spec
+    templates:
+      - statefulset.yaml
+    set:
+      podAnnotations: {pod: annotated, add: this}
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            pod: annotated
+            add: this
+            foo: bar
+            hello: world
+
+  - it: validate podLabels and commonLabels in pod spec
+    templates:
+      - statefulset.yaml
+    set:
+      podLabels: {pod: labeled, add: this}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            pod: labeled
+            add: this
+            foo: bar
+            hello: world
+
+  - it: validate main container values
+    templates:
+      - statefulset.yaml
+    set:
+      image:
+        registry: docker.io
+        repository: harness/feature-signed
+        tag: 808xx
+        pullPolicy: Always
+        pullSecrets: [{name: mysecret}]
+      securityContext: {runAsUser: 1000}
+      lifecycleHooks:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "echo Hello"]
+      extraVolumeMounts: [{name: extras, mountPath: /extras}]
+      extraVolumes: [{name: extras, emptyDir: {}}]
+      resources:
+        limits:
+          cpu: 200m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - isSubset:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec
+          content:
+            command:
+              - "/bin/sh"
+              - "-c"
+              - "echo Hello"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extras
+            mountPath: /extras
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extras
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/harness/feature-signed:808xx
+
+  - it: validate image with global image registry overrdide
+    templates:
+      - statefulset.yaml
+    set:
+      global.imageRegistry: us.gcr.io
+      image:
+        registry: docker.io
+        repository: harness/feature-signed
+        tag: 808xx
+        pullSecrets: [{name: mysecret}]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: us.gcr.io/harness/feature-signed:808xx
+
+  - it: validate nodeSelector value
+    templates:
+      - statefulset.yaml
+    set:
+      nodeSelector: {disktype: ssd}
+    asserts:
+      - isSubset:
+          path: spec.template.spec.nodeSelector
+          content:
+            disktype: ssd
+
+  - it: validate tolerations value
+    templates:
+      - statefulset.yaml
+    set:
+      tolerations:
+        - key: "key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "key"
+            operator: "Equal"
+            value: "value"
+            effect: "NoSchedule"
+
+  - it: template with all values set
+    templates:
+      - statefulset.yaml
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+      global.commonAnnotations: {foo: bar, hello: world}
+      autoscaling.enabled: false
+      podAnnotations: {pod: annotated, add: this}
+      podLabels: {pod: labeled, add: this}
+      podSecurityContext: {fsGroup: 2000}
+      securityContext: {runAsUser: 1000}
+      nodeSelector: {disktype: ssd}
+      tolerations:
+        - key: "key"
+          operator: "Equal"
+          value: "value"
+          effect: "NoSchedule"
+      replicaCount: 3
+    asserts:
+      - notFailedTemplate: {}

--- a/tests/virtualService_test.yaml
+++ b/tests/virtualService_test.yaml
@@ -1,0 +1,131 @@
+---
+suite: test virtual service
+templates:
+  - virtualservice.yaml
+release:
+  namespace: harness-smp
+set:
+  global.istio.enabled: true
+  global.cg.enabled: true
+tests:
+  - it: should template without any override
+    asserts:
+      - notFailedTemplate: {}
+      - isKind:
+          of: VirtualService
+      - equal:
+          path: metadata.namespace
+          value: harness-smp
+
+  - it: should work with common annotations
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common labels
+    set:
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with common annotations and labels
+    set:
+      global.commonAnnotations: {foo: bar, hello: world}
+      global.commonLabels: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+      - isSubset:
+          path: metadata.labels
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with virtual service annotations
+    set:
+      virtualService.annotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+
+  - it: should work with virtual service annotations and common annotations
+    set:
+      virtualService.annotations: {service: annotated, add: this}
+      global.commonAnnotations: {foo: bar, hello: world}
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            foo: bar
+            hello: world
+            service: annotated
+            add: this
+
+  - it: should work with provided gateways
+    set:
+      global.istio.virtualService.gateways: ["test-gateway", "test-gateway2"]
+    asserts:
+      - lengthEqual:
+          path: spec.gateways
+          count: 2
+      - equal:
+          path: spec.gateways[0]
+          value: test-gateway
+      - equal:
+          path: spec.gateways[1]
+          value: test-gateway2
+
+  - it: should work with istio-gateway create enabled
+    set:
+      global.istio.gateway.create: true
+    asserts:
+      - contains:
+          path: spec.gateways
+          content:
+            istio-system/public
+
+  - it: should work with single host provided
+    set:
+      global.istio.virtualService.hosts: ["test-host"]
+    asserts:
+      - lengthEqual:
+          path: spec.hosts
+          count: 1
+      - equal:
+          path: spec.hosts[0]
+          value: test-host
+
+  - it: should work with multiple hosts provided
+    set:
+      global.istio.virtualService.hosts:
+        - "test-host"
+        - "test-host2"
+        - "test-host3"
+    asserts:
+      - lengthEqual:
+          path: spec.hosts
+          count: 3
+      - equal:
+          path: spec.hosts[0]
+          value: test-host
+      - equal:
+          path: spec.hosts[1]
+          value: test-host2
+      - equal:
+          path: spec.hosts[2]
+          value: test-host3


### PR DESCRIPTION
This PR adds common unit tests for helm charts per template. It includes tests for deployment, service, ingress, statefulsets, virtualService, config, hpa and pdb.
