### PR TITLE
fix: [SMP-2303]: removing storage from timescaledb override and adding PV sizes correctly 

### DIFF
--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -471,6 +471,11 @@ platform:
         tolerations: []
         podAnnotations: {}
         replicaCount: 1
+        # Increasing persistentVolumes size while upgrading a helm deployment
+        # will fail because these values are immutable for a statefulset.
+        # To increase the size, it requires to delete the statefulset
+        # and then upgrade. For more information follow this document
+        # https://developer.harness.io/docs/self-managed-enterprise-edition/advanced-configurations/increase-pv-size-statefulsets
         persistentVolumes:
           data:
             size: 100Gi

--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -471,14 +471,17 @@ platform:
         tolerations: []
         podAnnotations: {}
         replicaCount: 1
+        persistentVolumes:
+          data:
+            size: 100Gi
+          wal:
+            size: 1Gi
         resources:
           limits:
             memory: 512Mi
           requests:
             cpu: 0.3
             memory: 512Mi
-        storage:
-          capacity: 10Gi
     harness-secrets:
       enabled: true
     networking:

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -480,14 +480,17 @@ platform:
           enabled: false
         enabled: true
         replicaCount: 2
+        persistentVolumes:
+          data:
+            size: 100Gi
+          wal:
+            size: 1Gi
         resources:
           limits:
             memory: 2048Mi
           requests:
             cpu: 1
             memory: 2048Mi
-        storage:
-          capacity: 120Gi
     harness-secrets:
       enabled: true
     networking:

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -480,6 +480,11 @@ platform:
           enabled: false
         enabled: true
         replicaCount: 2
+        # Increasing persistentVolumes size while upgrading a helm deployment
+        # will fail because these values are immutable for a statefulset.
+        # To increase the size, it requires to delete the statefulset
+        # and then upgrade. For more information follow this document
+        # https://developer.harness.io/docs/self-managed-enterprise-edition/advanced-configurations/increase-pv-size-statefulsets
         persistentVolumes:
           data:
             size: 100Gi

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -393,6 +393,13 @@ platform:
         prometheus:
           enabled: false
         tolerations: []
+        persistentVolumes:
+          data:
+            enabled: true
+            size: 100Gi
+          wal:
+            enabled: true
+            size: 1Gi
     harness-secrets:
       enabled: true
       # -- learning-engine (taints, tolerations, and so on)


### PR DESCRIPTION
This PR removes the storage option in the override files for timescaledb and adds the correct PV option to set the data and wall sizes in override.