### PR TITLE
fix: [SMP-2375]: Convert waitForInitContainers as global override

### DIFF
--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -232,6 +232,15 @@ global:
     stsEndPointUrl: https://sts.us-east-2.amazonaws.com
     ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
     cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
+  waitForInitContainer:
+    enabled: true
+    image:
+      registry: docker.io
+      repository: harness/helm-init-container
+      pullPolicy: Always
+      tag: "latest"
+      digest: ""
+      imagePullSecrets: []
 ccm:
   # -- Set ccm.batch-processing.clickhouse.enabled to true for AWS infrastructure
   batch-processing:


### PR DESCRIPTION
waitForInit containers are now controlled by a common template function configurable at both global and service levels, with the service level having higher precedence.

Tested for multiple scenarios, refer to this: https://github.com/harness/harness-core/pull/57144#issuecomment-1885344654