### PR TITLE
fix: [PL-46444]: Convert waitForInitContainers as global override

### DIFF
--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -232,6 +232,15 @@ global:
     stsEndPointUrl: https://sts.us-east-2.amazonaws.com
     ecsEndPointUrl: https://ecs.us-east-2.amazonaws.com
     cloudwatchEndPointUrl: https://monitoring.us-east-2.amazonaws.com
+  waitForInitContainer:
+    enabled: true
+    image:
+      registry: docker.io
+      repository: harness/helm-init-container
+      pullPolicy: Always
+      tag: "latest"
+      digest: ""
+      imagePullSecrets: []
 ccm:
   # -- Set ccm.batch-processing.clickhouse.enabled to true for AWS infrastructure
   batch-processing:

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -238,7 +238,7 @@ global:
       registry: docker.io
       repository: harness/helm-init-container
       pullPolicy: Always
-      tag: "latest"
+      tag: "8e18fde"
       digest: ""
       imagePullSecrets: []
 ccm:


### PR DESCRIPTION
This PR
1. Converts waitForInitContainers as a global override
2. Add the updated image tag to the waitForInitContainers