### PR TITLE
adding shell script to configure vanity url in smp

### DIFF
--- a/src/harness/configure-vality-url.sh
+++ b/src/harness/configure-vality-url.sh
@@ -1,0 +1,27 @@
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <namespace> <accountId> <subdomainUrl>"
+    exit 1
+fi
+
+# Assign the first argument to namespace
+namespace="$1"
+
+# Assign the second argument to accountId
+accountId="$2"
+
+# Assign the second argument to subdomainUrl
+subdomainUrl="$3"
+
+MONGO_PASS=$(kubectl get secret -n $namespace mongodb-replicaset-chart -o jsonpath={.data.mongodb-root-password} | base64 --decode)
+kubectl exec -it mongodb-replicaset-chart-0 -n $namespace -- mongo <<EOF
+use admin
+db.auth('admin', '${MONGO_PASS}')
+use gateway
+db.account_refs.update({"uuid":"${accountId}"},{\$set:{"subdomainUrl": "${subdomainUrl}"}})
+db.account_refs.find()
+use harness
+db.accounts.update({"_id":"${accountId}"},{\$set:{"subdomainUrl": "${subdomainUrl}"}})
+db.accounts.find()
+EOF
+kubectl patch configmap ng-auth-ui -n $namespace --type merge -p '{"data":{"EXPECTED_HOSTNAME":"app.harness.io"}}'
+kubectl rollout restart -n $namespace deployment -l "app.kubernetes.io/name=ng-auth-ui"


### PR DESCRIPTION
Via this script user can configure vanity url in smp
test:
Ran this script and then installed the URL and ran shell script pipeline
<img width="1578" alt="Screenshot 2024-04-19 at 11 04 07 AM" src="https://github.com/harness/helm-charts/assets/83326992/2e655ad5-f3d7-46e0-96e5-4c4543cac90c">
