### PR TITLE
move ubuntu and ng-dashbaord-aggregator to pl bundle

### DIFF
--- a/src/airgap/airgap_input.txt
+++ b/src/airgap/airgap_input.txt
@@ -36,13 +36,14 @@
     queue-service-signed
     service-discovery-collector
     service-discovery-k8s-lifecycle-agent
+    ubuntu
+    ng-dashboard-aggregator-signed
+
 [cdng]:
     argocd
     gitops-agent
     haproxy
     gitops-service-signed
-    ubuntu
-    ng-dashboard-aggregator-signed
     gitops-agent-installer-helper
 
 [ci]:


### PR DESCRIPTION
move ubuntu and ng-dashbaord-aggregator to pl bundle