### PR TITLE
fix: [PL-55757]: remove seLinuxOptions from bitnami rendered security context

### DIFF
--- a/src/harness/templates/_helper.tpl
+++ b/src/harness/templates/_helper.tpl
@@ -11,3 +11,16 @@
     {{- printf "%d" $shortTag -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "common.compatibility.renderSecurityContext" -}}
+{{- $adaptedContext := .secContext -}}
+{{- if not .secContext.seLinuxOptions -}}
+{{/* If it is an empty object, we remove it from the resulting context because it causes validation issues */}}
+{{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+{{- end -}}
+{{/* Remove fields that are disregarded when running the container in privileged mode */}}
+{{- if $adaptedContext.privileged -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+{{- end -}}
+{{- omit $adaptedContext "enabled" | toYaml -}}
+{{- end -}}


### PR DESCRIPTION
- Currently, even we set seLinuxOptions to `null` or empty object {}, the field is still rendered by bitnami helper function and appears in the final security context.
- This causes problems where empty linux options is not allowed such as in gatekeeper policies
- This is a bug in bitnami chart and to fix it, we can have a function defined with same name as bitnami and omit the field if its empty.