### PR TITLE
Create update-setting-parentUniqueId.sh to re populate parentUniqueId with correct values

### DIFF
--- a/src/harness/scripts/update-setting-parentUniqueId.sh
+++ b/src/harness/scripts/update-setting-parentUniqueId.sh
@@ -1,0 +1,19 @@
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <namespace>"
+    exit 1
+fi
+
+namespace="$1"
+
+
+MONGO_PASS=$(kubectl get secret -n $namespace mongodb-replicaset-chart -o jsonpath={.data.mongodb-root-password} | base64 --decode)
+kubectl exec -it mongodb-replicaset-chart-0 -n $namespace -- mongo <<EOF
+use admin
+db.auth('admin', '${MONGO_PASS}')
+use ng-harness
+db.settings.dropIndex("accountIdentifier_parentUniqueId_identifier_userId_unique_idx");
+db.settings.dropIndex("uniqueId_1");
+db.settings.updateMany({ }, { \$unset: { "uniqueId": "", "parentUniqueId": "" } });
+db.uniqueIdParentIdMigrationStatus.deleteOne({ "entityClassName" : "NGSetting"});
+EOF
+kubectl rollout restart deployment ng-manager -n $namespace


### PR DESCRIPTION
We are encountering an issue where the User Settings migration process is incorrectly identifying values for Account Settings, resulting in incorrect data population for existing settings. To address this, we need to:

- Remove the unique indexes associated with both fields.
- Clear the prefilled data to correct the inaccuracies.
- Reset the migration flag to enable a re-run of the migration with the correct parameters.
- Restart the NG Manager to execute the updated migration.

This process will ensure that the migration runs accurately and populates the settings correctly.

This need to be done for folk who updated to any of the following versions of SMP:
0.17.0 0.17.1 0.17.2 0.18.0 0.18.1 
If they are upgrading to 0.17.3 and 0.18.2 directly from 0.16.x or any lower version this would not be needed 


Testing done:
- populate incorrect data for parentUniqueId then run the script. Validated unsetting of data and resetting with correct value. Validated correct listing on UI
- Re ran the script with correctly populated data & validated re population of data in UI and DB