### PR TITLE
techdebt: [PL-56063]: moving delegate version to helm umbrella charts

### DIFF
--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -463,6 +463,12 @@ platform:
       ADDITIONAL: ""
     nodeSelector: {}
     tolerations: []
+    immutable_delegate_docker_image:
+      image:
+        registry: docker.io
+        repository: harness/delegate
+        tag: 24.02.82308
+        digest: ""
   # -- log-service (taints, tolerations, and so on)
   log-service:
     affinity: {}

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -467,7 +467,7 @@ platform:
       image:
         registry: docker.io
         repository: harness/delegate
-        tag: 24.02.82308
+        tag: 00.00.00000
         digest: ""
   # -- log-service (taints, tolerations, and so on)
   log-service:


### PR DESCRIPTION
#### Current Approach:
We update the new delegate version in the harness-manager chart and then create a new patch release for the manager. This approach adds time to the overall sign-off pipeline runtime, making it difficult to release HF for delegate.

#### Proposed Approach:
Moving the delegate version to the umbrella charts, this way we won’t have to re-build the harness-manager chart

#### Testing
Tested this locally with helm template command to validate the correct delegate image is coming in the final chart

![Screenshot 2024-08-12 at 1 21 56 PM](https://github.com/user-attachments/assets/dfa80d4c-f942-4d21-b071-50598de645e2)
Delegate version set in umbrella values.yaml file

![Screenshot 2024-08-12 at 1 21 34 PM](https://github.com/user-attachments/assets/c1765bee-1dd7-434f-9dbe-3aa37ed42c9f)
Delegate version used in manager configmap