### PR TITLE
[PL-56494]: Adding script to update ingress objects for validation webhook issue

### DIFF
--- a/src/harness/scripts/update-ingress-objects.sh
+++ b/src/harness/scripts/update-ingress-objects.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Function to print usage information
+usage() {
+  echo "Usage: $0 <namespace>"
+  exit 1
+}
+
+# Check if correct number of arguments is provided
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+# Assign input argument to variable
+NAMESPACE=$1
+
+# Arrays for old and new Ingress names
+OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
+NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+
+# Loop through the arrays and process each Ingress
+for i in "${!OLD_INGRESS_NAMES[@]}"; do
+  OLD_INGRESS_NAME=${OLD_INGRESS_NAMES[$i]}
+  NEW_INGRESS_NAME=${NEW_INGRESS_NAMES[$i]}
+
+  # Check if the Ingress object exists in the specified namespace
+  if kubectl get ingress "$OLD_INGRESS_NAME" -n "$NAMESPACE" > /dev/null 2>&1; then
+    echo "Updating $OLD_INGRESS_NAME."
+
+    # Download the Ingress manifest
+    kubectl get ingress "$OLD_INGRESS_NAME" -n "$NAMESPACE" -o yaml > ingress-manifest.yaml
+
+    # Update the name in the manifest
+    yq -i ".metadata.name = \"$NEW_INGRESS_NAME\"" ingress-manifest.yaml
+
+    # Delete the old Ingress object
+    kubectl delete ingress "$OLD_INGRESS_NAME" -n "$NAMESPACE"
+
+    # Apply the updated Ingress manifest
+    kubectl apply -f ingress-manifest.yaml -n "$NAMESPACE"
+
+    # Clean up
+    rm ingress-manifest.yaml
+
+    echo "Updated $OLD_INGRESS_NAME to $NEW_INGRESS_NAME."
+
+  fi
+done

--- a/src/harness/scripts/update-ingress-objects.sh
+++ b/src/harness/scripts/update-ingress-objects.sh
@@ -1,22 +1,30 @@
 #!/bin/bash
 
-# Function to print usage information
-usage() {
-  echo "Usage: $0 <namespace>"
-  exit 1
-}
-
-# Check if correct number of arguments is provided
-if [ $# -ne 1 ]; then
-  usage
-fi
-
+read -p "Enter Namespace: " NAMESPACE
+read -p "Enter Harness Upgrade version (eg: 0.20.0): " VERSION
 # Assign input argument to variable
-NAMESPACE=$1
 
-# Arrays for old and new Ingress names
-OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
-NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+# Perform actions based on the version
+if [[ "$VERSION" == "0.20."* ]]; then
+  OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
+  NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+
+elif [[ "$VERSION" == "0.19."* ]]; then
+  OLD_INGRESS_NAMES=("pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
+  NEW_INGRESS_NAMES=("pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+
+elif [[ "$VERSION" == "0.18."* ]]; then
+  OLD_INGRESS_NAMES=("pipeline-service-smp-v1-apis" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
+  NEW_INGRESS_NAMES=("pipeline-service-v1-apis" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+
+elif [[ "$VERSION" == "0.17."* ]]; then
+  OLD_INGRESS_NAMES=("pipeline-service-smp-v1-apis" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
+  NEW_INGRESS_NAMES=("pipeline-service-v1-apis" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
+
+else
+  echo "Not required to run for version $VERSION"
+  exit 1
+fi
 
 # Loop through the arrays and process each Ingress
 for i in "${!OLD_INGRESS_NAMES[@]}"; do


### PR DESCRIPTION
From 0.17.x There have been changes in Ingress object names for services, creating issues with upgrading for customers who are running Ingress/Nginx with Validation Webhook.
To mitigate this issue we are going ahead with a script-based approach which will update the ingress names before upgrading to any 0.17.x and above version

This script will take the namespace and upgrade version as input and based on that it will update the required ingress objects.

Testing
For testing, I set up a validation webhook and applied the new ingress manifests which failed. After that, I ran the script which updated the ingress objects and then the new ingress manifest was applied successfully.
Also tested the script with half of the services already upgraded and it only changed the remaining ones as expected.