### PR TITLE
adding new ingress names for upgrade 0.21.0

### DIFF
--- a/src/harness/scripts/update-ingress-objects.sh
+++ b/src/harness/scripts/update-ingress-objects.sh
@@ -2,10 +2,16 @@
 
 read -p "Enter Namespace: " NAMESPACE
 read -p "Enter Harness Upgrade version (eg: 0.20.0): " VERSION
-# Assign input argument to variable
+if [[ "$VERSION" == "0.21."* ]]; then
+  read -p "Enter Helm Release Name (You can check release name by running 'helm ls -n $NAMESPACE'): " RELEASE_NAME
+fi
 
 # Perform actions based on the version
-if [[ "$VERSION" == "0.20."* ]]; then
+if [[ "$VERSION" == "0.21."* ]]; then
+  OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis" "ng-ce-ui" "chaos-manager" "migrator-api" "next-gen-ui" "ng-dashboard-aggregator" "chaos-k8s-ifs" "verification-svc" "ssca-ui" "ng-auth-ui" "nextgen-ce" "service-discovery-manager" "${RELEASE_NAME}-gitops" "${RELEASE_NAME}-sto-manager")
+  NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis" "ng-ce-ui-0" "chaos-manager-0" "migrator-0" "next-gen-ui-0" "ng-dashboard-aggregator-0" "chaos-k8s-ifs-0" "verification-svc-0" "ssca-ui-0" "ng-auth-ui-0" "nextgen-ce-0" "service-discovery-manager-0" "gitops-http" "sto-manager-0")
+
+elif [[ "$VERSION" == "0.20."* ]]; then
   OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis")
   NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis")
 


### PR DESCRIPTION
Updating ingress script to include new changes in Ingress for 0.21.0

I have tested this by verifying the required service Ingress has been updated.

Difference between ingress names after running the update script on 0.20.2 charts
https://www.diffchecker.com/pEaCBJ5g/

Difference between ingress names after upgrading to 0.21.0 charts
https://www.diffchecker.com/nNGBYXBL/

The difference in ingress between 0.20.0 and 0.21.0 is based on the script (The script compares ingress between two manifests and tells the difference between them)

0.20.0 -> 0.21.0
1. next-gen-ui -> next-gen-ui-0
2. ng-dashboard-aggregator -> ng-dashboard-aggregator-0
3. service-discovery-manager -> service-discovery-manager-0
4. release-name-gitops -> gitops-http
5. chaos-manager -> chaos-manager-0
6. ng-auth-ui -> ng-auth-ui-0
7. ssca-ui -> ssca-ui-0
8. nextgen-ce -> nextgen-ce-0
9. ng-ce-ui -> ng-ce-ui-0
10. migrator-api -> migrator-0
11. release-name-sto-manager -> sto-manager-0
12. verification-svc -> verification-svc-0
13. chaos-k8s-ifs -> chaos-k8s-ifs-0
14. - -> change-data-capture-0
