### PR TITLE
fix: [PL-57424]: Remove default secret from postgres

### DIFF
--- a/src/harness/override-demo.yaml
+++ b/src/harness/override-demo.yaml
@@ -145,8 +145,6 @@ platform:
             cpu: 500m
             memory: 1024Mi
       postgresql:
-        auth:
-          existingSecret: "postgres"
         primary:
           persistence:
             size: 8Gi

--- a/src/harness/override-large.yaml
+++ b/src/harness/override-large.yaml
@@ -138,8 +138,6 @@ platform:
             cpu: 6
             memory: 6Gi
       postgresql:
-        auth:
-          existingSecret: "postgres"
         primary:
           persistence:
             size: 8Gi

--- a/src/harness/override-medium.yaml
+++ b/src/harness/override-medium.yaml
@@ -137,8 +137,6 @@ platform:
             cpu: 4
             memory: 4096Mi
       postgresql:
-        auth:
-          existingSecret: "postgres"
         primary:
           persistence:
             size: 8Gi

--- a/src/harness/override-perf.yaml
+++ b/src/harness/override-perf.yaml
@@ -110,8 +110,6 @@ platform:
         storage:
           capacity: 120Gi
       postgresql:
-        auth:
-          existingSecret: postgres
         primary:
           persistence:
             size: 200Gi

--- a/src/harness/override-prod.yaml
+++ b/src/harness/override-prod.yaml
@@ -432,8 +432,6 @@ platform:
             cpu: 4
             memory: 8192Mi
       postgresql:
-        auth:
-          existingSecret: "postgres"
         primary:
           affinity: {}
           nodeSelector: {}

--- a/src/harness/override-small.yaml
+++ b/src/harness/override-small.yaml
@@ -137,8 +137,6 @@ platform:
             cpu: 2
             memory: 2048Mi
       postgresql:
-        auth:
-          existingSecret: "postgres"
         primary:
           persistence:
             size: 8Gi

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -376,8 +376,6 @@ platform:
           prometheus.io/scrape: 'false'
         tolerations: []
       postgresql:
-        auth:
-          existingSecret: "postgres"
         metrics:
           enabled: false
         podAnnotations:


### PR DESCRIPTION
We have modified databases to use external secrets if enabled but this requires no top-level override in any values. This PR aims to remove the default secret name from postgres overrides so that the bootstrap template function can take effect.