### PR TITLE
feat: [PL-57969]: Add Kubeversion field to add k8s supportable versions for helm-charts

### DIFF
--- a/src/harness/Chart.yaml
+++ b/src/harness/Chart.yaml
@@ -47,4 +47,4 @@ description: Helm Chart for deploying Harness.
 name: harness
 type: application
 version: 0.22.0
-kubeVersion: 1.28.0 - 1.30.0
+kubeVersion: ">=1.28.0"

--- a/src/harness/Chart.yaml
+++ b/src/harness/Chart.yaml
@@ -47,3 +47,4 @@ description: Helm Chart for deploying Harness.
 name: harness
 type: application
 version: 0.22.0
+kubeVersion: 1.28.0 - 1.30.0


### PR DESCRIPTION
Add Kubeversion field to add min k8s supportable versions for helm-charts

When the versions (1.24.0) are not incompatible, it will give this error -
<img width="880" alt="Screenshot 2024-11-13 at 1 29 53 PM" src="https://github.com/user-attachments/assets/3a564daa-db8e-4622-86b1-bacb5e3d2231">

When using k8s version 1.29.0 - 
<img width="961" alt="Screenshot 2024-11-13 at 1 31 15 PM" src="https://github.com/user-attachments/assets/8a09c275-ac76-473e-a46d-d3a7de1978d3">

