### PR TITLE
update ingress name script for 0.23.0

### DIFF
--- a/src/harness/scripts/update-ingress-objects.sh
+++ b/src/harness/scripts/update-ingress-objects.sh
@@ -2,12 +2,21 @@
 
 read -p "Enter Namespace: " NAMESPACE
 read -p "Enter Harness Upgrade version (eg: 0.22.0): " VERSION
-if [[ "$VERSION" == "0.21."* || "$VERSION" == "0.22."* ]]; then
+
+# Extract major and minor version
+MAJOR_MINOR_VERSION=$(echo $VERSION | awk -F. '{print $1"."$2}')
+
+# Compare the extracted version
+if [[ $(echo "$MAJOR_MINOR_VERSION >= 0.21" | bc) -eq 1 ]]; then
   read -p "Enter Helm Release Name (You can check release name by running 'helm ls -n $NAMESPACE'): " RELEASE_NAME
 fi
 
 # Perform actions based on the version
-if [[ "$VERSION" == "0.22."* ]]; then
+if [[ "$VERSION" == "0.23."* ]]; then
+  OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis" "ng-ce-ui" "chaos-manager" "migrator-api" "next-gen-ui" "ng-dashboard-aggregator" "chaos-k8s-ifs" "verification-svc" "ssca-ui" "ng-auth-ui" "nextgen-ce" "service-discovery-manager" "${RELEASE_NAME}-gitops" "${RELEASE_NAME}-sto-manager" "cv-nextgen" "cv-nextgen-smp-v1-apis" "gateway" "${RELEASE_NAME}-policy-mgmt" "ng-custom-dashboards" "telescopes" "cloud-info" "debezium-service" "event-service-api" "queue-service")
+  NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis" "ng-ce-ui-0" "chaos-manager-0" "migrator-0" "next-gen-ui-0" "ng-dashboard-aggregator-0" "chaos-k8s-ifs-0" "verification-svc-0" "ssca-ui-0" "ng-auth-ui-0" "nextgen-ce-0" "service-discovery-manager-0" "gitops-http" "sto-manager-0" "cv-nextgen-0" "cv-nextgen-1" "gateway-0" "policy-mgmt-0" "ng-custom-dashboards-0" "telescopes-0" "cloud-info-0" "debezium-service-0" "event-service-0" "queue-service-0")
+
+elif [[ "$VERSION" == "0.22."* ]]; then
   OLD_INGRESS_NAMES=("log-service" "pipeline-service-smp-v1-apis" "access-control" "ci-manager" "template-service" "ssca-manager" "ssca-manager-smp-v1-apis" "ng-ce-ui" "chaos-manager" "migrator-api" "next-gen-ui" "ng-dashboard-aggregator" "chaos-k8s-ifs" "verification-svc" "ssca-ui" "ng-auth-ui" "nextgen-ce" "service-discovery-manager" "${RELEASE_NAME}-gitops" "${RELEASE_NAME}-sto-manager" "cv-nextgen" "cv-nextgen-smp-v1-apis" "gateway" "${RELEASE_NAME}-policy-mgmt" "ng-custom-dashboards" "telescopes")
   NEW_INGRESS_NAMES=("log-service-0" "pipeline-service-v1-apis" "access-control-service" "ci-manager-0" "template-service-0" "ssca-manager-0" "ssca-manager-v1-apis" "ng-ce-ui-0" "chaos-manager-0" "migrator-0" "next-gen-ui-0" "ng-dashboard-aggregator-0" "chaos-k8s-ifs-0" "verification-svc-0" "ssca-ui-0" "ng-auth-ui-0" "nextgen-ce-0" "service-discovery-manager-0" "gitops-http" "sto-manager-0" "cv-nextgen-0" "cv-nextgen-1" "gateway-0" "policy-mgmt-0" "ng-custom-dashboards-0" "telescopes-0")
 


### PR DESCRIPTION
Adding comparison of 0.22.0 & 0.23.0 ingress objects

<img width="1176" alt="Screenshot 2024-11-28 at 5 33 34 PM" src="https://github.com/user-attachments/assets/8a3c02ce-4bd6-4a47-ae08-66e33ae20ab6">

