### PR TITLE
fix:[PIPE-22215]: Service accounts should include list and watch permissions on endpoints

### DIFF
--- a/tests/role_test.yaml
+++ b/tests/role_test.yaml
@@ -36,6 +36,8 @@ tests:
               - endpoints
             verbs:
               - get
+              - list
+              - watch
       - contains:
           path: rules
           content:


### PR DESCRIPTION
Allows Kubernetes client side load balancing behaviors.