### PR TITLE
fix: [PL-10000]: pdb ut fix

### DIFF
--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -8,8 +8,6 @@ set:
   pdb.create: true
   pdb.maxUnavailable: ""
   pdb.minAvailable: ""
-  global.pdb.maxUnavailable: ""
-  global.pdb.minAvailable: ""
 tests:
   - it: should not enable PodDisruptionBudget if global.pdb.create and pdb.create are false
     set:

--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -6,6 +6,10 @@ release:
 set:
   global.pdb.create: true
   pdb.create: true
+  pdb.maxUnavailable: ""
+  pdb.minAvailable: ""
+  global.pdb.maxUnavailable: ""
+  global.pdb.minAvailable: ""
 tests:
   - it: should not enable PodDisruptionBudget if global.pdb.create and pdb.create are false
     set:


### PR DESCRIPTION
If a local value is set in the service, as seen in this PR - https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/harness-core/commit/664cf250d6ff3faaef1f2da9ea8e6633491670fb
, it will cause tests that assume no preset value to fail.

To ensure the tests verify the default values and overrides correctly, explicitly set the local values to empty within the test setup.