### PR TITLE
fix: [PL-61162]: use external secrets if configured for mongo fcv job

### DIFF
--- a/src/harness/templates/mongo-preupgradejob.yaml
+++ b/src/harness/templates/mongo-preupgradejob.yaml
@@ -62,16 +62,11 @@ spec:
             echo "FCV is already at $desired_fcv. No upgrade needed."
           fi
         env:
-        - name: MONGO_USER
-          valueFrom:
-            secretKeyRef:
-              name: harness-secrets
-              key: mongodbUsername
-        - name: MONGO_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mongodb-replicaset-chart
-              key: mongodb-root-password
+        {{- $dbType := "mongo" -}}
+        {{- $globalDBCtx := $.Values.global.database.mongo -}}
+        {{- $globalDBESOSecretIdentifier := include "harnesscommon.dbv3.esoSecretCtxIdentifier" (dict "ctx" $ "dbType" $dbType "scope" "global") -}}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "MONGO_USER"  "defaultKubernetesSecretName" "harness-secrets" "defaultKubernetesSecretKey" "mongodbUsername" "extKubernetesSecretCtxs" (list $globalDBCtx.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalDBESOSecretIdentifier "secretCtx" $globalDBCtx.secrets.secretManagement.externalSecretsOperator))) | indent 8 }}
+        {{- include "harnesscommon.secrets.manageEnv" (dict "ctx" $ "variableName" "MONGO_PASSWORD"  "defaultKubernetesSecretName" "harness-secrets" "defaultKubernetesSecretKey" "mongodb-root-password" "extKubernetesSecretCtxs" (list $globalDBCtx.secrets.kubernetesSecrets) "esoSecretCtxs" (list (dict "secretCtxIdentifier" $globalDBESOSecretIdentifier "secretCtx" $globalDBCtx.secrets.secretManagement.externalSecretsOperator))) | indent 8 }}
         - name: MONGO_URI
           value: 'mongodb://$(MONGO_USER):$(MONGO_PASSWORD)@mongodb-replicaset-chart-0.mongodb-replicaset-chart/?authSource=admin'
       restartPolicy: Never


### PR DESCRIPTION
use external secrets if configured for mongo fcv job