### PR TITLE
feat: [DBOPS-2375]:  add previous version in smp-version-configmap.yaml

### DIFF
--- a/src/harness/templates/smp-version-configmap.yaml
+++ b/src/harness/templates/smp-version-configmap.yaml
@@ -1,6 +1,7 @@
-{{- /*
-This ConfigMap contains the global environment variables
-*/}}
+{{- $previousVersion := "" -}}
+{{- with (lookup "v1" "ConfigMap" .Release.Namespace "global-smp-config") -}}
+{{- $previousVersion = (get .data "SMP_VERSION" | default "") -}}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,3 +12,4 @@ metadata:
     version: {{ .Chart.Version }}
 data:
   SMP_VERSION: {{ .Chart.Version | quote }}
+  PREVIOUS_SMP_VERSION: {{ $previousVersion | quote }}

--- a/src/harness/templates/smp-version-configmap.yaml
+++ b/src/harness/templates/smp-version-configmap.yaml
@@ -1,3 +1,6 @@
+{{- /*
+This ConfigMap contains the global environment variables
+*/}}
 {{- $previousVersion := "" -}}
 {{- with (lookup "v1" "ConfigMap" .Release.Namespace "global-smp-config") -}}
 {{- $previousVersion = (get .data "SMP_VERSION" | default "") -}}


### PR DESCRIPTION
1. Capture previous version of the smp and the current version getting deployed as part of the SMP
2. by default, it will be empty
