### PR TITLE
fix: Add nil guard for lookup in NOTES.txt to prevent helm-diff failure

### DIFF
--- a/src/harness/templates/NOTES.txt
+++ b/src/harness/templates/NOTES.txt
@@ -19,6 +19,7 @@
 {{- if .Release.IsUpgrade }}
 {{- if .Values.upgrades.versionLookups.enabled }}
 {{- $hm_deployment := lookup "apps/v1" "Deployment" .Release.Namespace "harness-manager" -}}
+{{- if $hm_deployment }}
 {{- $var := $hm_deployment.metadata.labels }}
 {{- $version := ( get $var "helm.sh/chart" ) | trimPrefix "harness-manager-" }}
 {{- if .Values.platform.bootstrap.database.mongodbupgrades.mongoFCVUpgrade.enabled }}
@@ -28,6 +29,7 @@
   {{ fail "[ERROR] You are currently using SMP with MongoDB 5.0 and a direct upgrade to MongoDB 7.0 is not possible. Since SMP 0.22.0 and above uses Mongo 6.0, please, upgrade to SMP versions 0.22.0 through 0.32.0, which will install MongoDB 6.0. After that, you can upgrade to SMP 0.33.0 or later, which will update MongoDB to version 7.0." }}
 {{- else }}
   {{- printf "Mongo Upgrade Check looks good!" }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# Problem

Running `helm diff upgrade` against the Harness chart fails with:
```
Error: Failed to render chart: exit status 1: Error: template: harness/templates/NOTES.txt:22:26: executing "harness/templates/NOTES.txt" at <$hm_deployment.metadata.labels>: nil pointer evaluating interface {}.labels
```

# Root Cause

The `lookup` function at line 21 returns `nil` when called via `helm diff` plugin, as it cannot access the cluster API during diff rendering. Line 22 immediately dereferences `.metadata.labels` on the nil result.

Note: `helm template` is unaffected as it returns empty maps for `lookup` calls.

# Fix

Added a nil check (`{{- if $hm_deployment }}`) around the lookup result so the MongoDB version check is gracefully skipped when the deployment cannot be found.

# Validation

- **Before fix**: `helm diff upgrade harness harness/harness -n harness` → nil pointer error
- **After fix**: `helm diff upgrade harness <patched-chart> -n harness --reuse-values` → succeeds, renders diff correctly

# Affected Version

- harness-0.42.0