### PR TITLE
fix(pg-backup): default backup PVC storage class to postgres data PVC

### DIFF
--- a/src/harness/scripts/pg-backup-restore.sh
+++ b/src/harness/scripts/pg-backup-restore.sh
@@ -56,6 +56,12 @@ if [[ -z "${BACKUP_PVC_SIZE:-}" ]]; then
   BACKUP_PVC_SIZE="${BACKUP_PVC_SIZE:-50Gi}"
 fi
 
+# Resolve backup PVC storage class if not explicitly set.
+# Reuse the class of the postgres data PVC so the backup volume lands on the same sc
+if [[ -z "${BACKUP_PVC_STORAGE_CLASS:-}" ]]; then
+  BACKUP_PVC_STORAGE_CLASS=$(kubectl get pvc -n "$NAMESPACE" "data-${PG_POD}" -o jsonpath='{.spec.storageClassName}' 2>/dev/null || true)
+fi
+
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG_FILE="/tmp/pg-${ACTION}-${NAMESPACE}-${TIMESTAMP}.log"
 
@@ -77,7 +83,7 @@ pod_exec() { kubectl exec -n "$NAMESPACE" "$BACKUP_POD_NAME" -- bash -c "$1"; }
 ensure_pvc() {
   kubectl get pvc -n "$NAMESPACE" "$BACKUP_PVC_NAME" &>/dev/null && return
 
-  log "Creating PVC $BACKUP_PVC_NAME ($BACKUP_PVC_SIZE)..."
+  log "Creating PVC $BACKUP_PVC_NAME ($BACKUP_PVC_SIZE, storageClass: ${BACKUP_PVC_STORAGE_CLASS:-<cluster default>})..."
   local sc=""
   [[ -n "$BACKUP_PVC_STORAGE_CLASS" ]] && sc="  storageClassName: $BACKUP_PVC_STORAGE_CLASS"
 


### PR DESCRIPTION
## Problem

When `BACKUP_PVC_STORAGE_CLASS` is unset, `pg-backup-restore.sh` created the backup PVC with no `storageClassName`. On clusters where no StorageClass is annotated as default (airgap/on-prem, and the EKS cluster I tested on — `ebs-sc`/`efs-sc`/`gp2` with none marked default), the PVC never binds and stays **Pending** indefinitely, hanging the backup/restore.

## Fix

Resolve the storage class from the postgres data PVC (`data-${PG_POD}`) when not explicitly set, so the backup volume uses the same provisioner as postgres. If it can't be determined, leave it unset so the cluster default (via the DefaultStorageClass admission controller) still applies. The resolved class is now logged during PVC creation.

Explicit `BACKUP_PVC_STORAGE_CLASS` override still takes precedence.

## Testing

- `bash -n` syntax check passes.
- Verified in a live EKS cluster: resolution correctly picks up `gp2` from `data-postgres-0`, matching the postgres provisioner.

Made with [Cursor](https://cursor.com)