### PR TITLE
fix(pg-backup): default backup PVC storage class to postgres data PVC

### DIFF
--- a/src/harness/scripts/pg-backup-restore.sh
+++ b/src/harness/scripts/pg-backup-restore.sh
@@ -56,6 +56,12 @@ if [[ -z "${BACKUP_PVC_SIZE:-}" ]]; then
   BACKUP_PVC_SIZE="${BACKUP_PVC_SIZE:-50Gi}"
 fi
 
+# Resolve backup PVC storage class if not explicitly set.
+# Reuse the class of the postgres data PVC so the backup volume lands on the same sc
+if [[ -z "${BACKUP_PVC_STORAGE_CLASS:-}" ]]; then
+  BACKUP_PVC_STORAGE_CLASS=$(kubectl get pvc -n "$NAMESPACE" "data-${PG_POD}" -o jsonpath='{.spec.storageClassName}' 2>/dev/null || true)
+fi
+
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG_FILE="/tmp/pg-${ACTION}-${NAMESPACE}-${TIMESTAMP}.log"
 
@@ -77,7 +83,7 @@ pod_exec() { kubectl exec -n "$NAMESPACE" "$BACKUP_POD_NAME" -- bash -c "$1"; }
 ensure_pvc() {
   kubectl get pvc -n "$NAMESPACE" "$BACKUP_PVC_NAME" &>/dev/null && return
 
-  log "Creating PVC $BACKUP_PVC_NAME ($BACKUP_PVC_SIZE)..."
+  log "Creating PVC $BACKUP_PVC_NAME ($BACKUP_PVC_SIZE, storageClass: ${BACKUP_PVC_STORAGE_CLASS:-<cluster default>})..."
   local sc=""
   [[ -n "$BACKUP_PVC_STORAGE_CLASS" ]] && sc="  storageClassName: $BACKUP_PVC_STORAGE_CLASS"
 


### PR DESCRIPTION
When BACKUP_PVC_STORAGE_CLASS was unset, the backup PVC was created without a storageClassName. On clusters with no StorageClass annotated as default (e.g. airgap/on-prem, and this EKS cluster), the PVC never binds and stays Pending indefinitely.

Now resolve the class from the postgres data PVC (data-${PG_POD}) so the backup volume uses the same provisioner as postgres. If it can't be determined, leave it unset to let the cluster default apply. The resolved class is logged during PVC creation for easier debugging.