### PR TITLE
fix(pg-scripts): reuse postgres ServiceAccount for backup/upgrade pods

### DIFF
--- a/src/harness/scripts/pg-backup-restore.sh
+++ b/src/harness/scripts/pg-backup-restore.sh
@@ -46,9 +46,11 @@ BACKUP_POD_NAME="pg-backup-job"
 PG_PASSWORD_SECRET="${PG_PASSWORD_SECRET:-postgres}"
 PG_PASSWORD_SECRET_KEY="${PG_PASSWORD_SECRET_KEY:-postgres-password}"
 
-# Read image and pull secret from the postgres StatefulSet
+# Read image, pull secret, and service account from the postgres StatefulSet.
+# Reuse postgres's SA so the pod inherits its SCC (OpenShift).
 BACKUP_IMAGE="${BACKUP_IMAGE:-$(kubectl get sts -n "$NAMESPACE" "$PG_STS_NAME" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)}"
 IMAGE_PULL_SECRET=$(kubectl get sts -n "$NAMESPACE" "$PG_STS_NAME" -o jsonpath='{.spec.template.spec.imagePullSecrets[0].name}' 2>/dev/null || true)
+PG_SERVICE_ACCOUNT="${PG_SERVICE_ACCOUNT:-$(kubectl get sts -n "$NAMESPACE" "$PG_STS_NAME" -o jsonpath='{.spec.template.spec.serviceAccountName}' 2>/dev/null || true)}"
 
 # Size backup PVC to match postgres data PVC
 if [[ -z "${BACKUP_PVC_SIZE:-}" ]]; then
@@ -106,7 +108,10 @@ launch_pod() {
   [[ -n "$IMAGE_PULL_SECRET" ]] && pull_secret="  imagePullSecrets:
   - name: $IMAGE_PULL_SECRET"
 
-  log "Launching pod ($BACKUP_IMAGE)..."
+  local sa_line=""
+  [[ -n "$PG_SERVICE_ACCOUNT" ]] && sa_line="  serviceAccountName: $PG_SERVICE_ACCOUNT"
+
+  log "Launching pod ($BACKUP_IMAGE, serviceAccount: ${PG_SERVICE_ACCOUNT:-<default>})..."
   cat <<EOF | kubectl apply -n "$NAMESPACE" -f -
 apiVersion: v1
 kind: Pod
@@ -114,6 +119,7 @@ metadata:
   name: $BACKUP_POD_NAME
 spec:
   restartPolicy: Never
+${sa_line}
 ${pull_secret}
   securityContext:
     runAsUser: 1001

--- a/src/harness/scripts/pg-upgrade.sh
+++ b/src/harness/scripts/pg-upgrade.sh
@@ -41,8 +41,10 @@ if [[ -z "$PG_NEW_IMAGE" || -z "$UPGRADE_IMAGE" ]]; then
   exit 1
 fi
 
-# --- Image pull secret (read from postgres StatefulSet at runtime) ---
+# --- Image pull secret + service account (read from postgres StatefulSet at runtime) ---
+# Reuse postgres's SA so the pod inherits its SCC (OpenShift).
 IMAGE_PULL_SECRET=$(kubectl get sts -n "$NAMESPACE" "$PG_STS_NAME" -o jsonpath='{.spec.template.spec.imagePullSecrets[0].name}' 2>/dev/null || true)
+PG_SERVICE_ACCOUNT="${PG_SERVICE_ACCOUNT:-$(kubectl get sts -n "$NAMESPACE" "$PG_STS_NAME" -o jsonpath='{.spec.template.spec.serviceAccountName}' 2>/dev/null || true)}"
 
 UPGRADE_POD="pg-upgrade-job"
 
@@ -220,6 +222,7 @@ log "StatefulSet: $PG_STS_NAME"
 log "New image: $PG_NEW_IMAGE"
 log "Upgrade image: $UPGRADE_IMAGE"
 [[ -n "$IMAGE_PULL_SECRET" ]] && log "Image pull secret: $IMAGE_PULL_SECRET"
+[[ -n "$PG_SERVICE_ACCOUNT" ]] && log "Service account: $PG_SERVICE_ACCOUNT"
 
 # -----------------------------------------------
 # Version pre-check
@@ -287,6 +290,9 @@ _build_pod_spec() {
   - name: $IMAGE_PULL_SECRET"
   fi
 
+  local sa_line=""
+  [[ -n "$PG_SERVICE_ACCOUNT" ]] && sa_line="  serviceAccountName: $PG_SERVICE_ACCOUNT"
+
   cat <<EOF
 apiVersion: v1
 kind: Pod
@@ -294,6 +300,7 @@ metadata:
   name: $UPGRADE_POD
 spec:
   restartPolicy: Never
+${sa_line}
 ${pull_secret_block}
   securityContext:
     runAsUser: 0


### PR DESCRIPTION
## Problem

`pg-backup-restore.sh` and `pg-upgrade.sh` launch helper pods without setting `serviceAccountName`, so they fall back to the namespace `default` SA. On OpenShift, the SecurityContextConstraints (SCC) that permits the pod's securityContext is bound to postgres's own ServiceAccount — a pod on `default` doesn't inherit it and can be rejected by admission.

## Fix

Auto-read `serviceAccountName` from the postgres StatefulSet (same pattern already used for image and imagePullSecret) and set it on the backup and upgrade pods. Overridable via `PG_SERVICE_ACCOUNT`; if it can't be resolved the field is omitted, preserving prior behavior.

## Testing

- `bash -n` on both scripts.
- Live end-to-end backup run (EKS): backup pod launched with `serviceAccount: postgres`, reached Ready, dumped all 9 databases successfully.
- Server-side dry-run of both rendered pod specs accepted with the SA injected.

Note: OpenShift SCC inheritance (the motivation) can't be exercised on EKS, but the SA is now correctly propagated, which is the prerequisite.

Made with [Cursor](https://cursor.com)