### PR TITLE
feat: Onboard harness-db-migrator to SMP umbrella chart

### DIFF
--- a/src/bundle-manifest.yaml
+++ b/src/bundle-manifest.yaml
@@ -302,6 +302,7 @@ modules:
     bucket_path: "dbdevops"
     images:
       - db-devops-service-signed
+      - harness-db-migrator-signed
 
   code:
     description: "Code Repository"

--- a/src/docker-repo-map.yaml
+++ b/src/docker-repo-map.yaml
@@ -274,6 +274,10 @@ db-devops-service:
   image:
     registry: docker.io
     repository: harnesssecure/db-devops-service-signed
+harness-db-migrator:
+  image:
+    registry: docker.io
+    repository: harnesssecure/harness-db-migrator-signed
 code-api:
   image:
     registry: docker.io

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -44,7 +44,7 @@ global:
   dbops:
     enabled: false
   # -- Enable DB DevOps managed migrations (harness-db-migrator)
-  dbopsMigration:
+  dbopsHelmMigration:
     enabled: true
   # -- Enable to install Harness Code services (CODE)
   code:

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -845,6 +845,11 @@ code:
       enabled: false
     nodeSelector: {}
     tolerations: []
+db-devops:
+  db-devops-service:
+    config:
+      INDEX_MANAGER_ENABLED: "false"
+      DBOPS_MIGRATIONS_ENABLED: "true"
 postmigrationCheck:
   enabled: true
   image:

--- a/src/harness/values.yaml
+++ b/src/harness/values.yaml
@@ -43,6 +43,9 @@ global:
   # -- Enable to install Database Devops (DB Devops)
   dbops:
     enabled: false
+  # -- Enable DB DevOps managed migrations (harness-db-migrator)
+  dbopsMigration:
+    enabled: true
   # -- Enable to install Harness Code services (CODE)
   code:
     enabled: false

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.109.1
+  version: 1.104.1
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: harness-db-migrator
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.0.0
+  version: 2.3.0
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.109.1
+  version: 1.111.0
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.111.0
+  version: 1.111.0-rollback-e12-force-failure-ca6075
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -5,10 +5,6 @@ dependencies:
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
   version: 1.104.1
-- condition: global.dbops.enabled
-  name: harness-db-migrator
-  repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 2.3.0
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.111.0-rollback-e12-force-failure-ca6075
+  version: 1.111.0
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.104.1
+  version: 1.109.1
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -4,7 +4,7 @@ dependencies:
 - condition: global.dbops.enabled
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.111.0
+  version: 1.109.1
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/db-devops/Chart.yaml
+++ b/src/modules/db-devops/Chart.yaml
@@ -5,6 +5,10 @@ dependencies:
   name: db-devops-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
   version: 1.104.1
+- condition: global.dbops.enabled
+  name: harness-db-migrator
+  repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
+  version: 1.0.0
 description: A Helm chart for Harness DB devops
 name: db-devops
 type: application

--- a/src/modules/platform/Chart.yaml
+++ b/src/modules/platform/Chart.yaml
@@ -95,7 +95,7 @@ dependencies:
 - condition: global.dbopsHelmMigration.enabled
   name: harness-db-migrator
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 2.4.0-main-7bfe9c
+  version: 2.4.0
 description: Helm chart for Harness Platform
 name: platform
 type: application

--- a/src/modules/platform/Chart.yaml
+++ b/src/modules/platform/Chart.yaml
@@ -92,6 +92,10 @@ dependencies:
   name: queue-service
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
   version: 1.11.0
+- condition: global.dbopsHelmMigration.enabled
+  name: harness-db-migrator
+  repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
+  version: 1.0.0-snapshot-2026-08-14-06-31-28-7bfe9c
 description: Helm chart for Harness Platform
 name: platform
 type: application

--- a/src/modules/platform/Chart.yaml
+++ b/src/modules/platform/Chart.yaml
@@ -95,7 +95,7 @@ dependencies:
 - condition: global.dbopsHelmMigration.enabled
   name: harness-db-migrator
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 2.4.0
+  version: 1.0.0-snapshot-2026-08-14-06-31-28-7bfe9c
 description: Helm chart for Harness Platform
 name: platform
 type: application

--- a/src/modules/platform/Chart.yaml
+++ b/src/modules/platform/Chart.yaml
@@ -95,7 +95,7 @@ dependencies:
 - condition: global.dbopsHelmMigration.enabled
   name: harness-db-migrator
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 2.4.0
+  version: 2.4.0-main-7bfe9c
 description: Helm chart for Harness Platform
 name: platform
 type: application

--- a/src/modules/platform/Chart.yaml
+++ b/src/modules/platform/Chart.yaml
@@ -95,7 +95,7 @@ dependencies:
 - condition: global.dbopsHelmMigration.enabled
   name: harness-db-migrator
   repository: oci://us-west1-docker.pkg.dev/gcr-prod/harness-helm-artifacts
-  version: 1.0.0-snapshot-2026-08-14-06-31-28-7bfe9c
+  version: 2.4.0
 description: Helm chart for Harness Platform
 name: platform
 type: application


### PR DESCRIPTION
- Add harness-db-migrator as dependency in db-devops module chart
- Add docker-repo-map entry for image promotion signing
- Add to airgap bundle-manifest (dbdevops images)
- Add global.dbopsMigration.enabled (default true) for migration control