### PR TITLE
fix: [DEL-10723]: Whitelist iterator-config.yaml in deployment_test.yaml

### DIFF
--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -4,6 +4,7 @@ templates:
   - deployment.yaml
   - config.yaml
   - secret.yaml
+  - iterator-config.yaml
 release:
   namespace: harness-smp
 tests:


### PR DESCRIPTION
cg-manager's deployment.yaml needs to include (print $.Template.BasePath "/iterator-config.yaml") for a checksum/iterator-config annotation, but this suite's templates: whitelist only loaded deployment.yaml, config.yaml, and secret.yaml, so the include failed under helm-unittest even though helm template rendered fine.

helm-unittest silently skips whitelisted template paths that don't exist in a given chart, so adding iterator-config.yaml here is a no-op for every other chart (verified against 120-ng-manager: 26/26 still passing) and only takes effect for cg-manager, which is the only chart with this file.