### PR TITLE
fix:[CI-24717]: Offboard buildkit from SMP airgap bundle

### DIFF
--- a/src/bundle-manifest.yaml
+++ b/src/bundle-manifest.yaml
@@ -140,7 +140,6 @@ modules:
       - buildx-ecr
       - buildx-gar
       - buildx-gcr
-      - buildkit
       - docker
       - ecr
       - gar


### PR DESCRIPTION
## Summary
- Offboard `buildkit` from `src/bundle-manifest.yaml` (`ci-plugins`) because ci-manager no longer renders `harness/buildkit` (harness-core CI-24717).
- Follows [SMP: Offboard an image](https://harness.atlassian.net/wiki/spaces/PLATFORM/pages/22392406067/SMP+Onboarding+a+new+Image#Offboard-an-image): remove the image from `bundle-manifest.yaml`.
- No `docker-repo-map.yaml` change: there is no `buildkit` key in that file.

## Test plan
- [ ] Helm_Unit_Tests / Bundle Image Check on harness-core PR 123459 passes after this lands
- [ ] Confirm `buildkit` is gone from `modules.ci-plugins.images` only; `buildx*` entries remain


Made with [Cursor](https://cursor.com)